### PR TITLE
cluster: add entry to clusterview for defining current master.

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -327,7 +327,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	}
 
 	if cv != nil {
-		if !started && p.id == cv.GetMasterID() {
+		if !started && p.id == cv.Master {
 			// If the clusterView says we are master but we cannot get
 			// instance status or start then stop here, if we are slave then we can
 			// recover
@@ -360,7 +360,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 
 	// cv != nil
 
-	masterID := cv.GetMasterID()
+	masterID := cv.Master
 	log.Debugf("masterID: %s", masterID)
 
 	master := membersState[masterID]

--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -85,6 +85,7 @@ func (mr *MemberRole) Copy() *MemberRole {
 
 type ClusterView struct {
 	Version     int
+	Master      string
 	MembersRole MembersRole
 	ChangeTime  time.Time
 }
@@ -96,21 +97,6 @@ func (cv *ClusterView) Copy() *ClusterView {
 	ncv := *cv
 	ncv.MembersRole = cv.MembersRole.Copy()
 	return &ncv
-}
-
-func (cv *ClusterView) GetMasterID() string {
-	if cv == nil {
-		return ""
-	}
-	if cv.MembersRole == nil {
-		return ""
-	}
-	for id, mr := range cv.MembersRole {
-		if mr.Follow == "" {
-			return id
-		}
-	}
-	return ""
 }
 
 func (cv *ClusterView) GetFollowersIDs(id string) []string {


### PR DESCRIPTION
Deducing the master from an empty follow entry is not enough. In future
old master will be set to follow the new master only when the new master has
converged to the new cluster view (to avoid old master resetting itself and
failing to follow the new master). For doing this multiple members can have an
empty follow entry.