### PR TITLE
sentinel: updateClusterView: update follow id only if master converged.

### DIFF
--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -14,7 +14,10 @@
 
 package cluster
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
 
 type MembersState map[string]*MemberState
 
@@ -63,6 +66,10 @@ func (m *MemberState) MarkOK() {
 
 type MembersRole map[string]*MemberRole
 
+func NewMembersRole() MembersRole {
+	return make(MembersRole)
+}
+
 func (msr MembersRole) Copy() MembersRole {
 	nmsr := MembersRole{}
 	for k, v := range msr {
@@ -88,6 +95,27 @@ type ClusterView struct {
 	Master      string
 	MembersRole MembersRole
 	ChangeTime  time.Time
+}
+
+// NewClusterView return an initialized clusterView with Version: 0, zero
+// ChangeTime, no Master and empty MembersRole.
+func NewClusterView() *ClusterView {
+	return &ClusterView{
+		MembersRole: NewMembersRole(),
+	}
+}
+
+// Equals checks if the clusterViews are the same. It ignores the ChangeTime.
+func (cv *ClusterView) Equals(ncv *ClusterView) bool {
+	if cv == nil {
+		if ncv == nil {
+			return true
+		}
+		return false
+	}
+	return cv.Version == ncv.Version &&
+		cv.Master == cv.Master &&
+		reflect.DeepEqual(cv.MembersRole, ncv.MembersRole)
 }
 
 func (cv *ClusterView) Copy() *ClusterView {


### PR DESCRIPTION
 Now updateClusterView changes members follow id only when the master is
converged to the current clusterview.

This avoids members dropping their database and trying to sync (pg_basebackup)
to new master if this is not ready since it can bring to a state where no
members have data if the new elected master cannot promote itself or dies
before promoting.

Additionally it always returns a clusterView also if nothing has changed from
the previous one.