### PR TITLE
cluster: save member ID in memberState and memberRole structs.

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -423,6 +423,7 @@ func (s *Sentinel) updateMembersState(membersState cluster.MembersState, members
 		if _, ok := newMembersState[id]; !ok {
 			newMembersState[id] = &cluster.MemberState{
 				ErrorStartTime:     time.Time{},
+				ID:                 mi.ID,
 				ClusterViewVersion: mi.ClusterViewVersion,
 				Host:               mi.Host,
 				Port:               mi.Port,
@@ -436,6 +437,7 @@ func (s *Sentinel) updateMembersState(membersState cluster.MembersState, members
 	for id, mi := range membersInfo {
 		if mi.Changed(newMembersState[id]) {
 			newMembersState[id] = &cluster.MemberState{
+				ID:                 mi.ID,
 				ClusterViewVersion: mi.ClusterViewVersion,
 				Host:               mi.Host,
 				Port:               mi.Port,

--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -30,6 +30,7 @@ func (mss MembersState) Copy() MembersState {
 }
 
 type MemberState struct {
+	ID                 string
 	ErrorStartTime     time.Time
 	ClusterViewVersion int
 	Host               string
@@ -79,6 +80,7 @@ func (msr MembersRole) Copy() MembersRole {
 }
 
 type MemberRole struct {
+	ID     string
 	Follow string
 }
 


### PR DESCRIPTION
This is useful for accessing them directly without the need to keep it in
another variable.