### PR TITLE
cluster: rename timeline "Start" to "Switchpoint"

### DIFF
--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -44,9 +44,9 @@ func (mi *MemberInfo) Changed(m *MemberState) bool {
 }
 
 type PostgresTimeLineHistory struct {
-	TimelineID uint64
-	Start      uint64
-	Reason     string
+	TimelineID  uint64
+	SwitchPoint uint64
+	Reason      string
 }
 type PostgresState struct {
 	Initialized     bool


### PR DESCRIPTION
In the timeline history file the lsn is where the timeline switched. Calling it
"start" is quite confusing.