### PR TITLE
sentinel: check nil PGState in cluster initialization.

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -484,17 +484,16 @@ func (s *Sentinel) updateClusterView(cv *cluster.ClusterView, membersState clust
 		if len(membersState) > 1 {
 			return nil, fmt.Errorf("cannot init cluster, more than 1 member registered")
 		}
-		for id, _ := range membersState {
-			log.Debugf("masterID: %s", id)
-			if id != "" {
-				log.Infof("Initializing cluster with master: %s", id)
-				wantedMasterID = id
+		for id, m := range membersState {
+			if m.PGState == nil {
+				return nil, fmt.Errorf("cannot init cluster using member %q since its pg state is unknown", id)
 			}
+			log.Infof("Initializing cluster with master: %q", id)
+			wantedMasterID = id
 			break
 		}
 	} else {
 		masterID := cv.Master
-		log.Debugf("masterID: %s", masterID)
 
 		masterOK := true
 		master, ok := membersState[masterID]

--- a/cmd/sentinel/sentinel_test.go
+++ b/cmd/sentinel/sentinel_test.go
@@ -40,7 +40,7 @@ func TestUpdateClusterView(t *testing.T) {
 		{
 			cv: cluster.NewClusterView(),
 			membersState: cluster.MembersState{
-				"01": &cluster.MemberState{},
+				"01": &cluster.MemberState{PGState: &cluster.PostgresState{Initialized: true}},
 			},
 			outCV: &cluster.ClusterView{
 				Version: 1,


### PR DESCRIPTION
Do not choose a member as the first cluster member if its PGState is unknown.