### PR TITLE
sentinel: fix XlogPos check in GetBestSlave

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -236,7 +236,7 @@ func (s *Sentinel) GetBestStandby(cv *cluster.ClusterView, membersState cluster.
 			bestID = id
 			continue
 		}
-		if membersState[id].PGState.XLogPos > m.PGState.XLogPos {
+		if m.PGState.XLogPos > membersState[bestID].PGState.XLogPos {
 			bestID = id
 		}
 	}


### PR DESCRIPTION
m.PGState.XLogPos was compared with itself instead of the current best
slave.