### PR TITLE
keeper: check if master timeline is forked before our position.

### DIFF
--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -43,18 +43,30 @@ func (mi *MemberInfo) Changed(m *MemberState) bool {
 	return false
 }
 
+type PostgresTimeLinesHistory []*PostgresTimeLineHistory
+
 type PostgresTimeLineHistory struct {
 	TimelineID  uint64
 	SwitchPoint uint64
 	Reason      string
 }
+
+func (tlsh PostgresTimeLinesHistory) GetTimelineHistory(id uint64) *PostgresTimeLineHistory {
+	for _, tlh := range tlsh {
+		if tlh.TimelineID == id {
+			return tlh
+		}
+	}
+	return nil
+}
+
 type PostgresState struct {
-	Initialized     bool
-	Role            common.Role
-	SystemID        string
-	TimelineID      uint64
-	XLogPos         uint64
-	TimelineHistory []PostgresTimeLineHistory
+	Initialized      bool
+	Role             common.Role
+	SystemID         string
+	TimelineID       uint64
+	XLogPos          uint64
+	TimelinesHistory PostgresTimeLinesHistory
 }
 
 type MembersDiscoveryInfo []*MemberDiscoveryInfo

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -27,12 +27,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sorintlab/stolon/Godeps/_workspace/src/golang.org/x/net/context"
-
 	"github.com/sorintlab/stolon/common"
 
 	"github.com/sorintlab/stolon/Godeps/_workspace/src/github.com/coreos/pkg/capnslog"
 	_ "github.com/sorintlab/stolon/Godeps/_workspace/src/github.com/lib/pq"
+	"github.com/sorintlab/stolon/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
 var (

--- a/pkg/postgresql/utils_test.go
+++ b/pkg/postgresql/utils_test.go
@@ -1,0 +1,68 @@
+// Copyright 2015 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgresql
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sorintlab/stolon/Godeps/_workspace/src/github.com/davecgh/go-spew/spew"
+	"github.com/sorintlab/stolon/pkg/cluster"
+)
+
+func TestParseTimeLineHistory(t *testing.T) {
+	tests := []struct {
+		contents string
+		tlsh     cluster.PostgresTimeLinesHistory
+		err      error
+	}{
+		{
+			contents: "",
+			tlsh:     cluster.PostgresTimeLinesHistory{},
+			err:      nil,
+		},
+		{
+			contents: `1	0/5000090	no recovery target specified`,
+			tlsh: cluster.PostgresTimeLinesHistory{
+				{
+					TimelineID:  1,
+					SwitchPoint: 83886224,
+					Reason:      "no recovery target specified",
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for i, tt := range tests {
+		tlsh, err := parseTimeLinesHistory(tt.contents)
+		t.Logf("test #%d", i)
+		if tt.err != nil {
+			if err == nil {
+				t.Errorf("got no error, wanted error: %v", tt.err)
+			} else if tt.err.Error() != err.Error() {
+				t.Errorf("got error: %v, wanted error: %v", err, tt.err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(tlsh, tt.tlsh) {
+				t.Errorf(spew.Sprintf("#%d: wrong timeline history: got: %#+v, want: %#+v", i, tlsh, tt.tlsh))
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
If a standby is elected as the new master, the other standbys will switch syncing
to the new master. If for any reasons the elected standby was behind other standbys
it will fork a new timeline before the other standbys. The other standbys cannot
sync with it but will need a full resync (pg_basebackup at the moment).