### PR TITLE
*: Handle synchronous replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stolon - PostgreSQL cloud native manager
+# stolon - PostgreSQL cloud native HA replication manager
 
 [![Build Status](https://semaphoreci.com/api/v1/projects/fb01aecd-c3d5-407b-a157-7d5365e9e4b6/565617/badge.svg)](https://semaphoreci.com/sorintlab/stolon)
 
@@ -9,6 +9,7 @@ stolon is a cloud native PostgreSQL manager for PostgreSQL high availability. It
 * leverages PostgreSQL streaming replication
 * works inside kubernetes letting you handle persistent high availability
 * uses [etcd](https://github.com/coreos/etcd) as an high available data store and for leader election
+* asynchronous (default) and synchronous replication.
 
 ## Architecture
 

--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -55,7 +55,7 @@ type config struct {
 var cfg config
 
 func init() {
-	cmdProxy.PersistentFlags().StringVar(&cfg.etcdEndpoints, "etcd-endpoints", "http://127.0.0.1:4001,http://127.0.0.1:2379", "a comma-delimited list of etcd endpoints")
+	cmdProxy.PersistentFlags().StringVar(&cfg.etcdEndpoints, "etcd-endpoints", common.DefaultEtcdEndpoints, "a comma-delimited list of etcd endpoints")
 	cmdProxy.PersistentFlags().StringVar(&cfg.clusterName, "cluster-name", "", "cluster name")
 	cmdProxy.PersistentFlags().StringVar(&cfg.listenAddress, "listen-address", "127.0.0.1", "proxy listening address")
 	cmdProxy.PersistentFlags().StringVar(&cfg.port, "port", "5432", "proxy listening port")

--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -60,7 +60,7 @@ type config struct {
 var cfg config
 
 func init() {
-	cmdSentinel.PersistentFlags().StringVar(&cfg.etcdEndpoints, "etcd-endpoints", "http://127.0.0.1:4001,http://127.0.0.1:2379", "a comma-delimited list of etcd endpoints")
+	cmdSentinel.PersistentFlags().StringVar(&cfg.etcdEndpoints, "etcd-endpoints", common.DefaultEtcdEndpoints, "a comma-delimited list of etcd endpoints")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.clusterName, "cluster-name", "", "cluster name")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.keeperKubeLabelSelector, "keeper-kube-label-selector", "", "label selector for discoverying stolon-keeper(s) under kubernetes")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.keeperPort, "keeper-port", "5431", "stolon-keeper(s) listening port (used by kubernetes discovery)")

--- a/common/common.go
+++ b/common/common.go
@@ -23,6 +23,8 @@ const (
 	SentinelLeaseName = "sentinel-leader"
 
 	DefaultEtcdRequestTimeout = 5 * time.Second
+
+	DefaultEtcdEndpoints = "http://127.0.0.1:4001,http://127.0.0.1:2379"
 )
 
 type Role uint8

--- a/doc/syncrepl.md
+++ b/doc/syncrepl.md
@@ -1,0 +1,19 @@
+# Synchronous replication
+
+**Note:** this is temporary. In future you can update the cluster config using a stolon client (`stolonctl`) instead of manually writing the full cluster config inside etcd since this is quite error prone.
+
+You can enable/disable synchronous replication at any time and the keepers will reconfigure themselves.
+
+To do this, you should write the cluster config to the etcd path: `/stolon/cluster/$CLUSTERNAME/config` using for example `curl` or `etcdctl`.
+
+## Enable synchronous replication.
+
+Assuming that you cluster name is `mycluster` and etcd is listening on localhost:2379:
+```
+curl http://127.0.0.1:2379/v2/keys/stolon/cluster/mycluster/config -XPUT -d value={ "synchronousreplication" : true }'
+```
+
+or with etcdctl
+```
+etcdctl set /stolon/cluster/stolon-cluster/config '{ "synchronousreplication" : true }'
+```

--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"reflect"
+	"sort"
 	"time"
 )
 
@@ -129,6 +130,7 @@ func (cv *ClusterView) Copy() *ClusterView {
 	return &ncv
 }
 
+// Returns a sorted list of followersIDs
 func (cv *ClusterView) GetFollowersIDs(id string) []string {
 	followersIDs := []string{}
 	for memberID, mr := range cv.MembersRole {
@@ -136,6 +138,7 @@ func (cv *ClusterView) GetFollowersIDs(id string) []string {
 			followersIDs = append(followersIDs, memberID)
 		}
 	}
+	sort.Strings(followersIDs)
 	return followersIDs
 }
 

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -27,23 +27,25 @@ const (
 
 var (
 	DefaultConfig = Config{
-		RequestTimeout:       10 * time.Second,
-		SleepInterval:        5 * time.Second,
-		MemberFailInterval:   20 * time.Second,
-		PGReplUser:           "repluser",
-		PGReplPassword:       "replpassword",
-		MaxStandbysPerSender: 3,
+		RequestTimeout:         10 * time.Second,
+		SleepInterval:          5 * time.Second,
+		MemberFailInterval:     20 * time.Second,
+		PGReplUser:             "repluser",
+		PGReplPassword:         "replpassword",
+		MaxStandbysPerSender:   3,
+		SynchronousReplication: false,
 	}
 )
 
 // jsonConfig is a copy of Config with all the time.Duration types converted to duration.
 type jsonConfig struct {
-	RequestTimeout       duration `json:",omitempty"`
-	SleepInterval        duration `json:",omitempty"`
-	MemberFailInterval   duration `json:",omitempty"`
-	PGReplUser           string   `json:",omitempty"`
-	PGReplPassword       string   `json:",omitempty"`
-	MaxStandbysPerSender uint     `json:",omitempty"`
+	RequestTimeout         duration `json:",omitempty"`
+	SleepInterval          duration `json:",omitempty"`
+	MemberFailInterval     duration `json:",omitempty"`
+	PGReplUser             string   `json:",omitempty"`
+	PGReplPassword         string   `json:",omitempty"`
+	MaxStandbysPerSender   uint     `json:",omitempty"`
+	SynchronousReplication bool     `json:",omitempty"`
 }
 
 type Config struct {
@@ -54,33 +56,41 @@ type Config struct {
 	// Interval after the first fail to declare a member as not healthy.
 	MemberFailInterval time.Duration
 	// PostgreSQL replication username
-	PGReplUser string `json:",omitempty"`
+	PGReplUser string
 	// PostgreSQL replication password
-	PGReplPassword string `json:",omitempty"`
+	PGReplPassword string
 	// Max number of standbys for every sender. A sender can be a master or
 	// another standby (with cascading replication).
-	MaxStandbysPerSender uint `json:",omitempty"`
+	MaxStandbysPerSender uint
+	// Use Synchronous replication between master and its standbys
+	SynchronousReplication bool
+}
+
+func (c *Config) MarshalJSON() ([]byte, error) {
+	return json.Marshal(configToJsonConfig(c))
 }
 
 func configToJsonConfig(c *Config) *jsonConfig {
 	return &jsonConfig{
-		RequestTimeout:       duration(c.RequestTimeout),
-		SleepInterval:        duration(c.SleepInterval),
-		MemberFailInterval:   duration(c.MemberFailInterval),
-		PGReplUser:           c.PGReplUser,
-		PGReplPassword:       c.PGReplPassword,
-		MaxStandbysPerSender: c.MaxStandbysPerSender,
+		RequestTimeout:         duration(c.RequestTimeout),
+		SleepInterval:          duration(c.SleepInterval),
+		MemberFailInterval:     duration(c.MemberFailInterval),
+		PGReplUser:             c.PGReplUser,
+		PGReplPassword:         c.PGReplPassword,
+		MaxStandbysPerSender:   c.MaxStandbysPerSender,
+		SynchronousReplication: c.SynchronousReplication,
 	}
 }
 
 func jsonConfigToConfig(c *jsonConfig) *Config {
 	return &Config{
-		RequestTimeout:       time.Duration(c.RequestTimeout),
-		SleepInterval:        time.Duration(c.SleepInterval),
-		MemberFailInterval:   time.Duration(c.MemberFailInterval),
-		PGReplUser:           c.PGReplUser,
-		PGReplPassword:       c.PGReplPassword,
-		MaxStandbysPerSender: c.MaxStandbysPerSender,
+		RequestTimeout:         time.Duration(c.RequestTimeout),
+		SleepInterval:          time.Duration(c.SleepInterval),
+		MemberFailInterval:     time.Duration(c.MemberFailInterval),
+		PGReplUser:             c.PGReplUser,
+		PGReplPassword:         c.PGReplPassword,
+		MaxStandbysPerSender:   c.MaxStandbysPerSender,
+		SynchronousReplication: c.SynchronousReplication,
 	}
 }
 

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -82,14 +82,15 @@ func TestParseConfig(t *testing.T) {
 		},
 		// All options defined
 		{
-			in: `{ "requestTimeout": "10s", "sleepInterval": "10s", "memberFailInterval": "100s", "pgrepluser": "username", "pgreplpassword": "password", "maxstandbyspersender": 5 }`,
+			in: `{ "requestTimeout": "10s", "sleepInterval": "10s", "memberFailInterval": "100s", "pgrepluser": "username", "pgreplpassword": "password", "maxstandbyspersender": 5, "synchronousreplication": true}`,
 			cfg: mergeDefaultConfig(&Config{
-				RequestTimeout:       10 * time.Second,
-				SleepInterval:        10 * time.Second,
-				MemberFailInterval:   100 * time.Second,
-				PGReplUser:           "username",
-				PGReplPassword:       "password",
-				MaxStandbysPerSender: 5,
+				RequestTimeout:         10 * time.Second,
+				SleepInterval:          10 * time.Second,
+				MemberFailInterval:     100 * time.Second,
+				PGReplUser:             "username",
+				PGReplPassword:         "password",
+				MaxStandbysPerSender:   5,
+				SynchronousReplication: true,
 			}),
 			err: nil,
 		},
@@ -134,6 +135,9 @@ func mergeDefaultConfig(ic *Config) *Config {
 	}
 	if ic.MaxStandbysPerSender != 0 {
 		c.MaxStandbysPerSender = ic.MaxStandbysPerSender
+	}
+	if ic.SynchronousReplication != false {
+		c.SynchronousReplication = ic.SynchronousReplication
 	}
 	return &c
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -70,7 +70,7 @@ func (e *EtcdManager) NewLeaseManager() lease.Manager {
 	return lease.NewEtcdLeaseManager(e.kAPI, e.etcdPath, e.requestTimeout)
 }
 
-func (e *EtcdManager) SetClusterConfig(cfg cluster.Config) (*etcd.Response, error) {
+func (e *EtcdManager) SetClusterConfig(cfg *cluster.Config) (*etcd.Response, error) {
 	cfgj, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, err

--- a/test
+++ b/test
@@ -92,7 +92,7 @@ if [ -n "$INTEGRATION" ]; then
 	export STKEEPER_BIN=${BINDIR}/stolon-keeper
 	export STSENTINEL_BIN=${BINDIR}/stolon-sentinel
 	export STPROXY_BIN=${BINDIR}/stolon-proxy
-	go test $@ -v ${REPO_PATH}/tests/integration
+	go test -timeout 20m $@ -v ${REPO_PATH}/tests/integration
 fi
 
 echo "Success"

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -41,7 +41,7 @@ type TestKeeper struct {
 	db        *sql.DB
 }
 
-func NewTestKeeper(dir string, cluster string) (*TestKeeper, error) {
+func NewTestKeeper(dir string, clusterName string) (*TestKeeper, error) {
 	configFile, err := ioutil.TempFile(dir, "conf")
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func NewTestKeeper(dir string, cluster string) (*TestKeeper, error) {
 	port2 := ln2.Addr().(*net.TCPAddr).Port
 
 	args = append(args, fmt.Sprintf("--id=%s", id))
-	args = append(args, fmt.Sprintf("--cluster-name=%s", cluster))
+	args = append(args, fmt.Sprintf("--cluster-name=%s", clusterName))
 	args = append(args, fmt.Sprintf("--port=%d", port))
 	args = append(args, fmt.Sprintf("--pg-port=%d", port2))
 	args = append(args, fmt.Sprintf("--data-dir=%s", dataDir))
@@ -298,12 +298,12 @@ type TestSentinel struct {
 	args        []string
 }
 
-func NewTestSentinel(dir string, cluster string) (*TestSentinel, error) {
+func NewTestSentinel(dir string, clusterName string) (*TestSentinel, error) {
 	u := uuid.NewV4()
 	id := fmt.Sprintf("%x", u[:4])
 
 	args := []string{}
-	args = append(args, fmt.Sprintf("--cluster-name=%s", cluster))
+	args = append(args, fmt.Sprintf("--cluster-name=%s", clusterName))
 	args = append(args, "--debug")
 	sentinelBin := os.Getenv("STSENTINEL_BIN")
 	if sentinelBin == "" {


### PR DESCRIPTION
Now users can define in the cluster config if they want synchronous
replication. When enabled the master server parameter `synchronous_standby_names`
will be set to the value of the followers defined in the cluster view.

Users can switch between async and sync replication at any time without the
need to restart anything.