### PR TITLE
postgresql: enable md5 auth for all the users.

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -461,8 +461,8 @@ func (p *Manager) writePgHba() error {
 	defer f.Close()
 
 	// TODO(sgotti) Do not set this but let the user provide its ph_hba.conf file/entries
-	f.WriteString(fmt.Sprintf("host all %s %s md5\n", p.replUser, "0.0.0.0/0"))
-	f.WriteString(fmt.Sprintf("host all %s %s md5\n", p.replUser, "::0/0"))
+	f.WriteString("host all all 0.0.0.0/0 md5\n")
+	f.WriteString("host all all ::0/0 md5\n")
 	// TODO(sgotti) Configure this dynamically based on our followers provided by the clusterview
 	f.WriteString(fmt.Sprintf("host replication %s %s md5\n", p.replUser, "0.0.0.0/0"))
 	f.WriteString(fmt.Sprintf("host replication %s %s md5\n", p.replUser, "::0/0"))


### PR DESCRIPTION
Also if this is an hack and not the final solution, it was addding access from
all the networks, for all the databases with md5 authentication only for the
replication user and not for all the users.