### PR TITLE
doc: fix curl command typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ stolon is a cloud native PostgreSQL manager for PostgreSQL high availability. It
 * leverages PostgreSQL streaming replication
 * works inside kubernetes letting you handle persistent high availability
 * uses [etcd](https://github.com/coreos/etcd) as an high available data store and for leader election
-* asynchronous (default) and synchronous replication.
+* asynchronous (default) and [synchronous](doc/syncrepl.md) replication.
 
 ## Architecture
 

--- a/doc/syncrepl.md
+++ b/doc/syncrepl.md
@@ -10,7 +10,7 @@ To do this, you should write the cluster config to the etcd path: `/stolon/clust
 
 Assuming that you cluster name is `mycluster` and etcd is listening on localhost:2379:
 ```
-curl http://127.0.0.1:2379/v2/keys/stolon/cluster/mycluster/config -XPUT -d value={ "synchronousreplication" : true }'
+curl http://127.0.0.1:2379/v2/keys/stolon/cluster/mycluster/config -XPUT -d value='{ "synchronousreplication" : true }'
 ```
 
 or with etcdctl


### PR DESCRIPTION
And in the meantime add a link to the syncrepl.md doc from the main
README.md.