### PR TITLE
keeper: run pgstate async from pgStateHandler.

### DIFF
--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -32,6 +32,9 @@ type MemberInfo struct {
 }
 
 func (m *MemberInfo) Copy() *MemberInfo {
+	if m == nil {
+		return nil
+	}
 	nm := *m
 	return &nm
 }
@@ -44,6 +47,15 @@ func (mi *MemberInfo) Changed(m *MemberState) bool {
 }
 
 type PostgresTimeLinesHistory []*PostgresTimeLineHistory
+
+func (tlsh PostgresTimeLinesHistory) Copy() PostgresTimeLinesHistory {
+	if tlsh == nil {
+		return nil
+	}
+	ntlsh := make(PostgresTimeLinesHistory, len(tlsh))
+	copy(ntlsh, tlsh)
+	return ntlsh
+}
 
 type PostgresTimeLineHistory struct {
 	TimelineID  uint64
@@ -67,6 +79,15 @@ type PostgresState struct {
 	TimelineID       uint64
 	XLogPos          uint64
 	TimelinesHistory PostgresTimeLinesHistory
+}
+
+func (p *PostgresState) Copy() *PostgresState {
+	if p == nil {
+		return nil
+	}
+	np := *p
+	np.TimelinesHistory = p.TimelinesHistory.Copy()
+	return &np
 }
 
 type MembersDiscoveryInfo []*MemberDiscoveryInfo

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -37,7 +37,11 @@ func setupServers(t *testing.T, dir string, numKeepers, numSentinels uint8, sync
 	if err != nil {
 		t.Fatalf("cannot create etcd manager: %v", err)
 	}
-	e.SetClusterConfig(&cluster.Config{SynchronousReplication: syncRepl})
+	e.SetClusterConfig(&cluster.Config{
+		SleepInterval:          5 * time.Second,
+		MemberFailInterval:     10 * time.Second,
+		SynchronousReplication: syncRepl,
+	})
 
 	tms := []*TestKeeper{}
 	tss := []*TestSentinel{}


### PR DESCRIPTION
Get pgstate at timed intervals instead of getting it during every pgState http
handler.