### PR TITLE
cluster: add Healthy field to KeeperState

### DIFF
--- a/cmd/sentinel/sentinel_test.go
+++ b/cmd/sentinel/sentinel_test.go
@@ -74,6 +74,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"01": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -81,6 +82,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"02": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -109,6 +111,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"01": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Unix(0, 0),
+					Healthy:            false,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -116,6 +119,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"02": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -144,6 +148,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"01": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Unix(0, 0),
+					Healthy:            false,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -151,6 +156,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"02": &cluster.KeeperState{
 					ClusterViewVersion: 2,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -181,6 +187,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"01": &cluster.KeeperState{
 					ClusterViewVersion: 2,
 					ErrorStartTime:     time.Unix(0, 0),
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -188,6 +195,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"02": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -217,6 +225,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"01": &cluster.KeeperState{
 					ClusterViewVersion: 1,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},
@@ -224,6 +233,7 @@ func TestUpdateClusterView(t *testing.T) {
 				"02": &cluster.KeeperState{
 					ClusterViewVersion: 2,
 					ErrorStartTime:     time.Time{},
+					Healthy:            true,
 					PGState: &cluster.PostgresState{
 						TimelineID: 0,
 					},

--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -33,6 +33,7 @@ func (kss KeepersState) Copy() KeepersState {
 type KeeperState struct {
 	ID                 string
 	ErrorStartTime     time.Time
+	Healthy            bool
 	ClusterViewVersion int
 	Host               string
 	Port               string
@@ -56,13 +57,13 @@ func (ks *KeeperState) Changed(ki *KeeperInfo) bool {
 	return false
 }
 
-func (ks *KeeperState) MarkError() {
+func (ks *KeeperState) SetError() {
 	if ks.ErrorStartTime.IsZero() {
 		ks.ErrorStartTime = time.Now()
 	}
 }
 
-func (ks *KeeperState) MarkOk() {
+func (ks *KeeperState) CleanError() {
 	ks.ErrorStartTime = time.Time{}
 }
 


### PR DESCRIPTION
Instead of always computing if keeper is healthy looking at the ErrorStartTime,
do this only in updateKeeperState.

This is useful for:

* get from an external client the keeper health state
* if clusterconfig KeeperFailInterval is lowered at runtime, sentinels won't consider
as healthy keepers already marked as unhealthy.