### PR TITLE
cluster: make cluster config part of the cluster view.

### DIFF
--- a/doc/simplecluster.md
+++ b/doc/simplecluster.md
@@ -6,6 +6,20 @@ This example assumes a running etcd server on localhost
 
 Note: under ubuntu the `initdb` command is not provided in the path. You should updated the exported `PATH` env variable or provide the `--pg-bin-path` command line option to the `stolon-keeper` command.
 
+### Start a sentinel
+
+The sentinel will become the sentinels leader for `stolon-cluster` and initialize the first clusterview.
+
+```
+./bin/stolon-sentinel --cluster-name stolon-cluster
+```
+
+```
+sentinel: id: 336d6e14
+sentinel: trying to acquire sentinels leadership
+sentinel: sentinel leadership acquired
+```
+
 ### Launch first keeper
 
 ```
@@ -26,18 +40,9 @@ postgresql: Stopping database
 postgresql: Starting database
 ```
 
-### Start a sentinel
-
-Now that the first keeper is active we can start a sentinel
+The sentinel will elect it as the master instance:
 
 ```
-./bin/stolon-sentinel --cluster-name stolon-cluster
-```
-
-```
-sentinel: id: 336d6e14
-sentinel: trying to acquire sentinels leadership
-sentinel: sentinel leadership acquired
 sentinel: Initializing cluster with master: "postgres0"
 sentinel: Updating proxy view to localhost:5432
 sentinel: I'm the sentinels leader

--- a/doc/syncrepl.md
+++ b/doc/syncrepl.md
@@ -1,3 +1,5 @@
+# Temporary not available due to architecture changes #
+
 # Synchronous replication
 
 **Note:** this is temporary. In future you can update the cluster config using a stolon client (`stolonctl`) instead of manually writing the full cluster config inside etcd since this is quite error prone.

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -13,6 +13,14 @@ in the [image](examples/kubernetes/image/docker) directory you'll find the Docke
 
 These example points to a single node etcd cluster on `http://10.245.1.1:4001`. You can change the ST${COMPONENT}_ETCD_ENDPOINTS environment variables in the definitions to point to the right etcd cluster.
 
+### Create the sentinel(s)
+
+```
+kubectl create -f stolon-sentinel.yaml
+```
+
+This will create a replication controller with one pod executing the stolon sentinel. You can also increase the number of replicas for stolon sentinels in the rc definition or do it later.
+
 ### Create the first stolon keeper
 Note: In this example the stolon keeper is a replication controller that, for every pod replica, uses a volume for stolon and postgreSQL data of `emptyDir` type. So it'll go away when the related pod is destroyed. This is just for easy testing. In production you should use a persistent volume. Actually (kubernetes 1.0), for working with persistent volumes you should define a different replication controller with `replicas=1` for every keeper instance.
 
@@ -22,7 +30,9 @@ kubectl create -f stolon-keeper.yaml
 ```
 
 This will create a replication controller that will create one pod executing the stolon keeper.
+The first keeper will initialize an empty postgreSQL instance and the sentinel will elect it as the master.
 
+Once the leader sentinel has elected the first master and created the initial cluster view you can add additional stolon keepers. Will do this later.
 
 ### Setup superuser password
 
@@ -63,15 +73,6 @@ ALTER ROLE
 ```
 you can now exit the shell.
 
-### Create the sentinel(s)
-
-```
-kubectl create -f stolon-sentinel.yaml
-```
-
-This will create a replication controller with one pod executing the stolon sentinel. You can also increase the number of replicas for stolon sentinels in the rc definition or do it later.
-
-Once the leader sentinel has elected the first master and created the initial cluster view you can add additional stolon keepers. Will do this later.
 
 ### Create the proxies
 

--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -98,6 +98,7 @@ type ClusterView struct {
 	Version     int
 	Master      string
 	KeepersRole KeepersRole
+	Config      *Config
 	ChangeTime  time.Time
 }
 
@@ -106,6 +107,7 @@ type ClusterView struct {
 func NewClusterView() *ClusterView {
 	return &ClusterView{
 		KeepersRole: NewKeepersRole(),
+		Config:      NewDefaultConfig(),
 	}
 }
 
@@ -128,6 +130,7 @@ func (cv *ClusterView) Copy() *ClusterView {
 	}
 	ncv := *cv
 	ncv.KeepersRole = cv.KeepersRole.Copy()
+	ncv.Config = cv.Config.Copy()
 	return &ncv
 }
 

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -97,7 +98,8 @@ func TestParseConfig(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		cfg, err := ParseConfig([]byte(tt.in))
+		var cfg *Config
+		err := json.Unmarshal([]byte(tt.in), &cfg)
 		if tt.err != nil {
 			if err == nil {
 				t.Errorf("got no error, wanted error: %v", tt.err)

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -70,32 +70,6 @@ func (e *EtcdManager) NewLeaseManager() lease.Manager {
 	return lease.NewEtcdLeaseManager(e.kAPI, e.etcdPath, e.requestTimeout)
 }
 
-func (e *EtcdManager) SetClusterConfig(cfg *cluster.Config) (*etcd.Response, error) {
-	cfgj, err := json.Marshal(cfg)
-	if err != nil {
-		return nil, err
-	}
-	path := filepath.Join(e.etcdPath, configFile)
-	opts := &etcd.SetOptions{}
-	return e.kAPI.Set(context.Background(), path, string(cfgj), opts)
-}
-
-func (e *EtcdManager) GetClusterConfig() (*cluster.Config, *etcd.Response, error) {
-	path := filepath.Join(e.etcdPath, configFile)
-	res, err := e.kAPI.Get(context.Background(), path, &etcd.GetOptions{Quorum: true})
-	if err != nil && !IsEtcdNotFound(err) {
-		log.Errorf("err: %v", err)
-		return nil, nil, err
-	} else if !IsEtcdNotFound(err) {
-		cfg, err := cluster.ParseConfig([]byte(res.Node.Value))
-		if err != nil {
-			return nil, nil, err
-		}
-		return cfg, res, nil
-	}
-	return cluster.NewDefaultConfig(), res, nil
-}
-
 func (e *EtcdManager) SetClusterData(mss cluster.KeepersState, cv *cluster.ClusterView, prevIndex uint64) (*etcd.Response, error) {
 	// write cluster view
 	cd := &cluster.ClusterData{

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -37,11 +37,16 @@ func setupServers(t *testing.T, dir string, numKeepers, numSentinels uint8, sync
 	if err != nil {
 		t.Fatalf("cannot create etcd manager: %v", err)
 	}
-	e.SetClusterConfig(&cluster.Config{
-		SleepInterval:          5 * time.Second,
-		KeeperFailInterval:     10 * time.Second,
-		SynchronousReplication: syncRepl,
-	})
+	// TODO(sgotti) change this to a call to the sentinel to change the
+	// cluster config (when the sentinel's code is done)
+	e.SetClusterData(cluster.KeepersState{},
+		&cluster.ClusterView{
+			Config: &cluster.Config{
+				SleepInterval:          5 * time.Second,
+				KeeperFailInterval:     10 * time.Second,
+				SynchronousReplication: syncRepl,
+			},
+		}, 0)
 
 	tms := []*TestKeeper{}
 	tss := []*TestSentinel{}

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -29,23 +29,30 @@ func TestInit(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	cluster := uuid.NewV4().String()
-	tm, err := NewTestKeeper(dir, cluster)
+	clusterName := uuid.NewV4().String()
+
+	ts, err := NewTestSentinel(dir, clusterName)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := ts.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	defer ts.Stop()
+	tm, err := NewTestKeeper(dir, clusterName)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	t.Logf("tm: %v", tm)
 
-	err = tm.Start()
-	if err != nil {
+	if err := tm.Start(); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	defer tm.Stop()
 
-	err = tm.WaitDBUp(60 * time.Second)
-	if err != nil {
+	if err := tm.WaitDBUp(60 * time.Second); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	t.Logf("database is up")
 
-	tm.Stop()
 }


### PR DESCRIPTION
This is preparation work for being able to configure the cluster config.

With this patch the cluster config is managed by the leader sentinel and is
part of the clusterview, so when it's updated the clusterview version will be
increased.

This patch will (temporary) disable the ability to setup synchronous
replication since it's not possible to write the clusterconfig directly to
etcd.