### PR TITLE
semaphoreci: add script for semaphoreci

### DIFF
--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Setup for semaphore ci
+
+if [ "${CI}" != "true" -o "${SEMAPHORE}" != "true" ]; then
+	echo "not on semaphoreci"
+	exit 1
+fi
+
+# Install and start etcd
+mkdir etcd
+cd etcd
+curl -L  https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz -o etcd-v2.2.1-linux-amd64.tar.gz
+tar xzvf etcd-v2.2.1-linux-amd64.tar.gz
+cd etcd-v2.2.1-linux-amd64
+start-stop-daemon -b --start --exec $PWD/etcd -- --data-dir=$PWD/
+cd ../../
+
+# Run tests
+export PATH=/usr/lib/postgresql/9.4/bin/:$PATH ; INTEGRATION=1 ./test


### PR DESCRIPTION
This scripts does the setup steps needed for semaphoreci and previously defined
in the semaphoreci ui.

Now the semaphoreci ui has only defined one thread that executes
`./scripts/semaphore.sh`