### PR TITLE
tests: start etcd inside tests.

### DIFF
--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -14,9 +14,8 @@ mkdir etcd
 cd etcd
 curl -L  https://github.com/coreos/etcd/releases/download/v2.2.1/etcd-v2.2.1-linux-amd64.tar.gz -o etcd-v2.2.1-linux-amd64.tar.gz
 tar xzvf etcd-v2.2.1-linux-amd64.tar.gz
-cd etcd-v2.2.1-linux-amd64
-start-stop-daemon -b --start --exec $PWD/etcd -- --data-dir=$PWD/
-cd ../../
+cd ../
 
 # Run tests
+export ETCD_BIN="${PWD}/etcd/etcd-v2.2.1-linux-amd64/etcd"
 export PATH=/usr/lib/postgresql/9.4/bin/:$PATH ; INTEGRATION=1 ./test

--- a/test
+++ b/test
@@ -92,6 +92,15 @@ if [ -n "$INTEGRATION" ]; then
 	export STKEEPER_BIN=${BINDIR}/stolon-keeper
 	export STSENTINEL_BIN=${BINDIR}/stolon-sentinel
 	export STPROXY_BIN=${BINDIR}/stolon-proxy
+	if [ -z ${ETCD_BIN} ]; then
+		if [ -z $(which etcd) ]; then
+			echo "cannot find etcd in PATH and ETCD_BIN environment variable not defined"
+			exit 1
+		fi
+		ETCD_BIN=$(which etcd)
+	fi
+	echo "using etcd from $ETCD_BIN"
+	export ETCD_BIN
 	go test -timeout 20m $@ -v ${REPO_PATH}/tests/integration
 fi
 


### PR DESCRIPTION
Instead of relying on an already running etcd, start it in the tests.