### PR TITLE
kubernetes: add readiness probe for stolon proxy.

### DIFF
--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -29,3 +29,8 @@ spec:
             value: "true"
         ports:
           - containerPort: 5432
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          initialDelaySeconds: 10
+          timeoutSeconds: 5


### PR DESCRIPTION
When the stolon proxy stops listening the readiness probe will detect this and
avoid sending requests to that pod.