### PR TITLE
keeper: validate id against postgres repl slot name rules.

### DIFF
--- a/pkg/postgresql/utils.go
+++ b/pkg/postgresql/utils.go
@@ -30,6 +30,10 @@ import (
 	"github.com/sorintlab/stolon/Godeps/_workspace/src/golang.org/x/net/context"
 )
 
+var (
+	ValidReplSlotName = regexp.MustCompile("^[a-z0-9_]+$")
+)
+
 func Exec(ctx context.Context, db *sql.DB, query string, args ...interface{}) (sql.Result, error) {
 	ch := make(chan struct {
 		res sql.Result
@@ -248,4 +252,8 @@ func GetTimelinesHistory(ctx context.Context, timeline uint64, replConnString st
 		return tlsh, nil
 	}
 	return nil, fmt.Errorf("query returned 0 rows")
+}
+
+func IsValidReplSlotName(name string) bool {
+	return ValidReplSlotName.MatchString(name)
 }

--- a/pkg/postgresql/utils_test.go
+++ b/pkg/postgresql/utils_test.go
@@ -66,3 +66,26 @@ func TestParseTimeLineHistory(t *testing.T) {
 	}
 
 }
+
+func TestValidReplSlotName(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"aaaaaaaa", true},
+		{"a12345aa", true},
+		{"_a1_2345aa_", true},
+		{"", false},
+		{"a-aaaaaaa", false},
+		{"_a1_-2345aa_", false},
+		{"ABC123", false},
+		{"$123", false},
+	}
+
+	for i, tt := range tests {
+		valid := IsValidReplSlotName(tt.name)
+		if valid != tt.valid {
+			t.Errorf("%d: replication slot name %q got valid: %t but wanted valid: %t", i, tt.name, valid, tt.valid)
+		}
+	}
+}


### PR DESCRIPTION
Since the keeper's id is used as the postgres replication slot name it needs to
be a valid replication slot name.

From the postgreSQL 9.4 manual: "Each replication slot has a name, which can
contain lower-case letters, numbers, and the underscore character."