### PR TITLE
kubernetes: on master branch use `sorintlab/stolon:master` docker image.

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -4,10 +4,16 @@ In this example you'll see how stolon can provide an high available postgreSQL c
 
 
 ## Docker image
-A prebuilt image is available on the dockerhub (sorintlab/stolon:0.1) and it's the one used by this example.
+Prebuilt images are available on the dockerhub, the images' tags are their release version. Additional images are available:
 
-in the [image](examples/kubernetes/image/docker) directory you'll find the Dockerfile to build the image used in this example. Once the image is built you should push it to the docker registry used by your kubernetes infrastructure.
+* `latest`: latest released image (actually not existing, it will apppear when the first release is done)
+* `master`: automatically built after every commit to the master branch.
 
+
+In the [image](examples/kubernetes/image/docker) directory you'll find the Dockerfile to build the image used in this example. Once the image is built you should push it to the docker registry used by your kubernetes infrastructure.
+
+`sorintlab/stolon:master` is the one used by the kubernetes definitions in this example.
+For a more stable testing you can use `sorintlab/stolon:latest` (when available)
 
 ## Cluster setup and tests
 

--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: stolon-keeper
-        image: sorintlab/stolon:0.1
+        image: sorintlab/stolon:master
         env:
           - name: KEEPER
             value: "true"

--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: stolon-proxy
-        image: sorintlab/stolon:0.1
+        image: sorintlab/stolon:master
         env:
           - name: PROXY
             value: "true"

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: stolon-sentinel
-        image: sorintlab/stolon:0.1
+        image: sorintlab/stolon:master
         env:
           - name: SENTINEL
             value: "true"


### PR DESCRIPTION
These will be changed in a release pointing to the actual released version.