### PR TITLE
Support pg_rewind

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -31,6 +31,10 @@ const (
 	DefaultPGReplPassword         = "replpassword"
 	DefaultMaxStandbysPerSender   = 3
 	DefaultSynchronousReplication = false
+
+	// PG_REWIND (TODO)
+	DefaultWalLogHints    = true
+	DefaultFullPageWrites = true
 )
 
 type NilConfig struct {

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -81,6 +81,7 @@ func TestParseConfig(t *testing.T) {
 			cfg: nil,
 			err: fmt.Errorf("config validation failed: max_standbys_per_sender must be at least 1"),
 		},
+
 		// All options defined
 		{
 			in: `{ "request_timeout": "10s", "sleep_interval": "10s", "keeper_fail_interval": "100s", "pg_repl_user": "username", "pg_repl_password": "password", "max_standbys_per_sender": 5, "synchronous_replication": true,


### PR DESCRIPTION
This is the first implementation to use pg_rewind. If pg_rewind can be used, stolon uses it to synchronize a standby with the primary.

This implementation can be run on a simple cluster. For using pg_rewind, assume that username is "postgres" and password is none.