### PR TITLE
Add InitWithMultipleKeepers cluster config option

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -24,24 +24,26 @@ import (
 const (
 	DefaultProxyCheckInterval = 5 * time.Second
 
-	DefaultRequestTimeout         = 10 * time.Second
-	DefaultSleepInterval          = 5 * time.Second
-	DefaultKeeperFailInterval     = 20 * time.Second
-	DefaultPGReplUser             = "repluser"
-	DefaultPGReplPassword         = "replpassword"
-	DefaultMaxStandbysPerSender   = 3
-	DefaultSynchronousReplication = false
+	DefaultRequestTimeout          = 10 * time.Second
+	DefaultSleepInterval           = 5 * time.Second
+	DefaultKeeperFailInterval      = 20 * time.Second
+	DefaultPGReplUser              = "repluser"
+	DefaultPGReplPassword          = "replpassword"
+	DefaultMaxStandbysPerSender    = 3
+	DefaultSynchronousReplication  = false
+	DefaultInitWithMultipleKeepers = false
 )
 
 type NilConfig struct {
-	RequestTimeout         *Duration          `json:"request_timeout,omitempty"`
-	SleepInterval          *Duration          `json:"sleep_interval,omitempty"`
-	KeeperFailInterval     *Duration          `json:"keeper_fail_interval,omitempty"`
-	PGReplUser             *string            `json:"pg_repl_user,omitempty"`
-	PGReplPassword         *string            `json:"pg_repl_password,omitempty"`
-	MaxStandbysPerSender   *uint              `json:"max_standbys_per_sender,omitempty"`
-	SynchronousReplication *bool              `json:"synchronous_replication,omitempty"`
-	PGParameters           *map[string]string `json:"pg_parameters,omitempty"`
+	RequestTimeout          *Duration          `json:"request_timeout,omitempty"`
+	SleepInterval           *Duration          `json:"sleep_interval,omitempty"`
+	KeeperFailInterval      *Duration          `json:"keeper_fail_interval,omitempty"`
+	PGReplUser              *string            `json:"pg_repl_user,omitempty"`
+	PGReplPassword          *string            `json:"pg_repl_password,omitempty"`
+	MaxStandbysPerSender    *uint              `json:"max_standbys_per_sender,omitempty"`
+	SynchronousReplication  *bool              `json:"synchronous_replication,omitempty"`
+	InitWithMultipleKeepers *bool              `json:"init_with_multiple_keepers,omitempty"`
+	PGParameters            *map[string]string `json:"pg_parameters,omitempty"`
 }
 
 type Config struct {
@@ -60,6 +62,8 @@ type Config struct {
 	MaxStandbysPerSender uint
 	// Use Synchronous replication between master and its standbys
 	SynchronousReplication bool
+	// Choose a random initial master when multiple keeper are registered
+	InitWithMultipleKeepers bool
 	// Map of postgres parameters
 	PGParameters map[string]string
 }
@@ -127,6 +131,9 @@ func (c *NilConfig) Copy() *NilConfig {
 	}
 	if c.SynchronousReplication != nil {
 		nc.SynchronousReplication = BoolP(*c.SynchronousReplication)
+	}
+	if c.InitWithMultipleKeepers != nil {
+		nc.InitWithMultipleKeepers = BoolP(*c.InitWithMultipleKeepers)
 	}
 	if c.PGParameters != nil {
 		nc.PGParameters = MapStringP(*c.PGParameters)
@@ -206,6 +213,9 @@ func (c *NilConfig) MergeDefaults() {
 	if c.SynchronousReplication == nil {
 		c.SynchronousReplication = BoolP(DefaultSynchronousReplication)
 	}
+	if c.InitWithMultipleKeepers == nil {
+		c.InitWithMultipleKeepers = BoolP(DefaultInitWithMultipleKeepers)
+	}
 	if c.PGParameters == nil {
 		c.PGParameters = &map[string]string{}
 	}
@@ -215,14 +225,15 @@ func (c *NilConfig) ToConfig() *Config {
 	nc := c.Copy()
 	nc.MergeDefaults()
 	return &Config{
-		RequestTimeout:         (*nc.RequestTimeout).Duration,
-		SleepInterval:          (*nc.SleepInterval).Duration,
-		KeeperFailInterval:     (*nc.KeeperFailInterval).Duration,
-		PGReplUser:             *nc.PGReplUser,
-		PGReplPassword:         *nc.PGReplPassword,
-		MaxStandbysPerSender:   *nc.MaxStandbysPerSender,
-		SynchronousReplication: *nc.SynchronousReplication,
-		PGParameters:           *nc.PGParameters,
+		RequestTimeout:          (*nc.RequestTimeout).Duration,
+		SleepInterval:           (*nc.SleepInterval).Duration,
+		KeeperFailInterval:      (*nc.KeeperFailInterval).Duration,
+		PGReplUser:              *nc.PGReplUser,
+		PGReplPassword:          *nc.PGReplPassword,
+		MaxStandbysPerSender:    *nc.MaxStandbysPerSender,
+		SynchronousReplication:  *nc.SynchronousReplication,
+		InitWithMultipleKeepers: *nc.InitWithMultipleKeepers,
+		PGParameters:            *nc.PGParameters,
 	}
 }
 

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -83,19 +83,20 @@ func TestParseConfig(t *testing.T) {
 		},
 		// All options defined
 		{
-			in: `{ "request_timeout": "10s", "sleep_interval": "10s", "keeper_fail_interval": "100s", "pg_repl_user": "username", "pg_repl_password": "password", "max_standbys_per_sender": 5, "synchronous_replication": true,
+			in: `{ "request_timeout": "10s", "sleep_interval": "10s", "keeper_fail_interval": "100s", "pg_repl_user": "username", "pg_repl_password": "password", "max_standbys_per_sender": 5, "synchronous_replication": true, "init_with_multiple_keepers": true,
 			       "pg_parameters": {
 			         "param01": "value01"
 				}
 			     }`,
 			cfg: mergeDefaults(&NilConfig{
-				RequestTimeout:         &Duration{10 * time.Second},
-				SleepInterval:          &Duration{10 * time.Second},
-				KeeperFailInterval:     &Duration{100 * time.Second},
-				PGReplUser:             StringP("username"),
-				PGReplPassword:         StringP("password"),
-				MaxStandbysPerSender:   UintP(5),
-				SynchronousReplication: BoolP(true),
+				RequestTimeout:          &Duration{10 * time.Second},
+				SleepInterval:           &Duration{10 * time.Second},
+				KeeperFailInterval:      &Duration{100 * time.Second},
+				PGReplUser:              StringP("username"),
+				PGReplPassword:          StringP("password"),
+				MaxStandbysPerSender:    UintP(5),
+				SynchronousReplication:  BoolP(true),
+				InitWithMultipleKeepers: BoolP(true),
 				PGParameters: &map[string]string{
 					"param01": "value01",
 				},

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -712,6 +712,24 @@ func (te *TestStore) WaitDown(timeout time.Duration) error {
 	return fmt.Errorf("timeout")
 }
 
+func WaitClusterViewWithMaster(e *store.StoreManager, timeout time.Duration) error {
+	start := time.Now()
+	for time.Now().Add(-timeout).Before(start) {
+		cv, _, err := e.GetClusterView()
+		if err != nil {
+			goto end
+		}
+		if cv != nil {
+			if cv.Master != "" {
+				return nil
+			}
+		}
+	end:
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timeout")
+}
+
 func WaitClusterViewMaster(master string, e *store.StoreManager, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
@@ -728,7 +746,6 @@ func WaitClusterViewMaster(master string, e *store.StoreManager, timeout time.Du
 		time.Sleep(2 * time.Second)
 	}
 	return fmt.Errorf("timeout")
-
 }
 
 // Hack to find a free tcp port


### PR DESCRIPTION
When initing a new cluster (with an empty db) it can be useful to be able to
start multiple keepers and let the sentinel randomly choose one as the master
(since they are both empty).

This will avoid the need to start one keeper, start the sentinel(s), wait for
the sentinel to elect the keeper as master, then start the other keeper(s).

To make this useful on startup, there's the need to be able to specify an
initial cluster config, this will come in a future patch.