### PR TITLE
tests: Fix getFreeTCPUDPPort

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -776,7 +776,7 @@ func getFreeTCPUDPPort() (string, string, error) {
 
 		lnudp, err := net.ListenPacket("udp", fmt.Sprintf("%s:%s", listenAddress, port))
 		if err != nil {
-			return "", "", err
+			continue
 		}
 		lnudp.Close()
 		return listenAddress, port, nil


### PR DESCRIPTION
If the udp port is in use don not return error but continue the loop.