### PR TITLE
Run tests in parallel

### DIFF
--- a/test
+++ b/test
@@ -122,7 +122,8 @@ if [ -n "$INTEGRATION" ]; then
 		exit 1
 	fi
 
-	go test -timeout 20m $@ -v ${REPO_PATH}/tests/integration
+	[ -z "$PARALLEL" ] && PARALLEL=4
+	go test -timeout 20m $@ -v -parallel ${PARALLEL} ${REPO_PATH}/tests/integration
 fi
 
 echo "Success"

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -36,7 +36,7 @@ func TestServerParameters(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	tstore, err := NewTestStore(dir)
+	tstore, err := NewTestStore(t, dir)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestServerParameters(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	tk, err := NewTestKeeper(dir, clusterName, tstore.storeBackend, storeEndpoints)
+	tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -29,13 +29,15 @@ import (
 )
 
 func TestInit(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	tstore, err := NewTestStore(dir)
+	tstore, err := NewTestStore(t, dir)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -50,7 +52,7 @@ func TestInit(t *testing.T) {
 
 	clusterName := uuid.NewV4().String()
 
-	ts, err := NewTestSentinel(dir, clusterName, tstore.storeBackend, storeEndpoints)
+	ts, err := NewTestSentinel(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -58,7 +60,7 @@ func TestInit(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	defer ts.Stop()
-	tk, err := NewTestKeeper(dir, clusterName, tstore.storeBackend, storeEndpoints)
+	tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -76,13 +78,15 @@ func TestInit(t *testing.T) {
 }
 
 func TestInitialClusterConfig(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	tstore, err := NewTestStore(dir)
+	tstore, err := NewTestStore(t, dir)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -113,7 +117,7 @@ func TestInitialClusterConfig(t *testing.T) {
 	defer tmpFile.Close()
 	tmpFile.WriteString(`{ "synchronous_replication": true }`)
 
-	ts, err := NewTestSentinel(dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--initial-cluster-config=%s", tmpFile.Name()))
+	ts, err := NewTestSentinel(t, dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--initial-cluster-config=%s", tmpFile.Name()))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -136,13 +140,15 @@ func TestInitialClusterConfig(t *testing.T) {
 }
 
 func TestExclusiveLock(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	defer os.RemoveAll(dir)
 
-	tstore, err := NewTestStore(dir)
+	tstore, err := NewTestStore(t, dir)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -160,7 +166,7 @@ func TestExclusiveLock(t *testing.T) {
 	u := uuid.NewV4()
 	id := fmt.Sprintf("%x", u[:4])
 
-	tk1, err := NewTestKeeperWithID(dir, id, clusterName, tstore.storeBackend, storeEndpoints)
+	tk1, err := NewTestKeeperWithID(t, dir, id, clusterName, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -174,7 +180,7 @@ func TestExclusiveLock(t *testing.T) {
 		t.Fatalf("expecting tk1 up but it's down")
 	}
 
-	tk2, err := NewTestKeeperWithID(dir, id, clusterName, tstore.storeBackend, storeEndpoints)
+	tk2, err := NewTestKeeperWithID(t, dir, id, clusterName, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -191,6 +197,8 @@ func TestExclusiveLock(t *testing.T) {
 }
 
 func TestKeeperPGConfDirBad(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -199,14 +207,14 @@ func TestKeeperPGConfDirBad(t *testing.T) {
 
 	clusterName := uuid.NewV4().String()
 
-	tstore, err := NewTestStore(dir)
+	tstore, err := NewTestStore(t, dir)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
 	// Test pgConfDir not absolute path
-	tk, err := NewTestKeeper(dir, clusterName, tstore.storeBackend, storeEndpoints, "--pg-conf-dir=not/absolute/path")
+	tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints, "--pg-conf-dir=not/absolute/path")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -219,7 +227,7 @@ func TestKeeperPGConfDirBad(t *testing.T) {
 	}
 
 	// Test unexistent pgConfDir
-	tk2, err := NewTestKeeper(dir, clusterName, tstore.storeBackend, storeEndpoints, "--pg-conf-dir=/unexistent-configuration-directory")
+	tk2, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints, "--pg-conf-dir=/unexistent-configuration-directory")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -240,7 +248,7 @@ func TestKeeperPGConfDirBad(t *testing.T) {
 		tmpFile.Close()
 		os.Remove(tmpFile.Name())
 	}()
-	tk3, err := NewTestKeeper(dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--pg-conf-dir=%s", tmpFile.Name()))
+	tk3, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--pg-conf-dir=%s", tmpFile.Name()))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -254,6 +262,8 @@ func TestKeeperPGConfDirBad(t *testing.T) {
 }
 
 func TestKeeperPGConfDirGood(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -262,7 +272,7 @@ func TestKeeperPGConfDirGood(t *testing.T) {
 
 	clusterName := uuid.NewV4().String()
 
-	tstore, err := NewTestStore(dir)
+	tstore, err := NewTestStore(t, dir)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -275,7 +285,7 @@ func TestKeeperPGConfDirGood(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	ts, err := NewTestSentinel(dir, clusterName, tstore.storeBackend, storeEndpoints)
+	ts, err := NewTestSentinel(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -291,7 +301,7 @@ func TestKeeperPGConfDirGood(t *testing.T) {
 	}
 	defer os.Remove(tmpDir)
 
-	tk, err := NewTestKeeper(dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--pg-conf-dir=%s", tmpDir))
+	tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--pg-conf-dir=%s", tmpDir))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}


### PR DESCRIPTION
since some integration tests are quite long (minutes), run them in
parallel.

To avoid unreadable logging (due multiple tests running in parallel),
use only the `testing` pkg logging functions so the output will be shown
only on error or at the end of every test (since we pass `-v` to `go
test`).

By default 4 parallel tests will be run. The parallelism level can be
configured with the PARALLEL environment variable when invoking the test
script.