### PR TITLE
keeper: resync from master only when needed.

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -548,6 +548,7 @@ func (s *Sentinel) updateClusterView(cv *cluster.ClusterView, keepersState clust
 	if cv.Master == wantedMasterID {
 		// wanted master is the previous one
 		masterState := keepersState[wantedMasterID]
+		// Set standbys to follow master only if it's healthy and converged to the current cv
 		if masterState.Healthy && s.isKeeperConverged(masterState, cv) {
 			for id, _ := range newKeepersRole {
 				if id == wantedMasterID {

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -231,10 +231,6 @@ func (p *Manager) Promote() error {
 	return nil
 }
 
-func (p *Manager) BecomeStandby(masterconnString string) error {
-	return p.WriteRecoveryConf(masterconnString)
-}
-
 func (p *Manager) CreateReplRole() error {
 	ctx, cancel := context.WithTimeout(context.Background(), p.requestTimeout)
 	defer cancel()

--- a/test
+++ b/test
@@ -67,7 +67,7 @@ if [ -n "${vetRes}" ]; then
 	exit 255
 fi
 
-echo "Checking govet -shadow..."
+echo "Checking govet -shadow ..."
 for path in $FMT; do
 	vetRes=$(go tool vet -shadow ${path})
 	if [ -n "${vetRes}" ]; then

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -104,10 +104,10 @@ func TestServerParameters(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	tk.cmd.Expect("postgres parameters changed, reloading postgres instance")
+	tk.cmd.ExpectTimeout("postgres parameters changed, reloading postgres instance", 30*time.Second)
 
 	// On the next keeper check they shouldn't be changed
-	tk.cmd.Expect("postgres parameters not changed")
+	tk.cmd.ExpectTimeout("postgres parameters not changed", 30*time.Second)
 
 	tk.Stop()
 
@@ -116,7 +116,7 @@ func TestServerParameters(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	tk.cmd.Expect("failed to start postgres:")
+	tk.cmd.ExpectTimeout("failed to start postgres:", 30*time.Second)
 
 	// Fix wrong parameters
 	pair, err = e.SetClusterData(cluster.KeepersState{},


### PR DESCRIPTION
Previously when switching an instance from master to standby role, a
full resync was always executed.

Sometimes an old master is on the same branch of the new one and can
become a standby without the need to full resync.