### PR TITLE
keeper: use followed node instead of master

### DIFF
--- a/pkg/postgresql/connstring.go
+++ b/pkg/postgresql/connstring.go
@@ -24,22 +24,22 @@ import (
 
 // This is based on github.com/lib/pq
 
-type connParams map[string]string
+type ConnParams map[string]string
 
-func (p connParams) Set(k, v string) {
+func (p ConnParams) Set(k, v string) {
 	p[k] = v
 }
 
-func (p connParams) Get(k string) (v string) {
+func (p ConnParams) Get(k string) (v string) {
 	return p[k]
 }
 
-func (p connParams) Isset(k string) bool {
+func (p ConnParams) Isset(k string) bool {
 	_, ok := p[k]
 	return ok
 }
 
-func (p connParams) Equals(cp connParams) bool {
+func (p ConnParams) Equals(cp ConnParams) bool {
 	return reflect.DeepEqual(p, cp)
 }
 
@@ -78,8 +78,8 @@ func (s *scanner) SkipSpaces() (rune, bool) {
 // ParseConnString parses the options from name and adds them to the values.
 //
 // The parsing code is based on conninfo_parse from libpq's fe-connect.c
-func ParseConnString(name string) (connParams, error) {
-	p := make(connParams)
+func ParseConnString(name string) (ConnParams, error) {
+	p := make(ConnParams)
 	s := newScanner(name)
 
 	for {
@@ -156,8 +156,8 @@ func ParseConnString(name string) (connParams, error) {
 }
 
 // URLToConnParams creates the connParams from the url.
-func URLToConnParams(urlStr string) (connParams, error) {
-	p := make(connParams)
+func URLToConnParams(urlStr string) (ConnParams, error) {
+	p := make(ConnParams)
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func URLToConnParams(urlStr string) (connParams, error) {
 	return p, nil
 }
 
-func (p connParams) ConnString() string {
+func (p ConnParams) ConnString() string {
 	var kvs []string
 	escaper := strings.NewReplacer(` `, `\ `, `'`, `\'`, `\`, `\\`)
 	for k, v := range p {

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -291,7 +291,7 @@ func (p *Manager) GetRole() (common.Role, error) {
 	return common.StandbyRole, nil
 }
 
-func (p *Manager) GetPrimaryConninfo() (connParams, error) {
+func (p *Manager) GetPrimaryConninfo() (ConnParams, error) {
 	regex, err := regexp.Compile(`\s*primary_conninfo\s*=\s*'(.*)'$`)
 	if err != nil {
 		return nil, err
@@ -369,7 +369,7 @@ func (p *Manager) WriteConf() error {
 	return nil
 }
 
-func (p *Manager) WriteRecoveryConf(masterconnString string) error {
+func (p *Manager) WriteRecoveryConf(followedConnString string) error {
 	f, err := ioutil.TempFile(p.dataDir, "recovery.conf")
 	if err != nil {
 		return err
@@ -380,9 +380,9 @@ func (p *Manager) WriteRecoveryConf(masterconnString string) error {
 	f.WriteString(fmt.Sprintf("primary_slot_name = '%s'\n", p.name))
 	f.WriteString("recovery_target_timeline = 'latest'\n")
 
-	if masterconnString != "" {
-		var cp connParams
-		cp, err = URLToConnParams(masterconnString)
+	if followedConnString != "" {
+		var cp ConnParams
+		cp, err = URLToConnParams(followedConnString)
 		if err != nil {
 			return err
 		}
@@ -415,8 +415,8 @@ func (p *Manager) writePgHba() error {
 	return nil
 }
 
-func (p *Manager) SyncFromMaster(masterconnString string) error {
-	cp, err := URLToConnParams(masterconnString)
+func (p *Manager) SyncFromFollowed(followedConnString string) error {
+	cp, err := URLToConnParams(followedConnString)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -412,7 +412,7 @@ func testOldMasterRestart(t *testing.T, syncRepl bool) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	// Wait old master synced with standby
-	if err := waitLines(t, master, 2, 30*time.Second); err != nil {
+	if err := waitLines(t, master, 2, 60*time.Second); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if err := master.WaitRole(common.StandbyRole, 30*time.Second); err != nil {


### PR DESCRIPTION
When configuring a standby node, use the reported followed node instead
of the master. This is actually the same node but will change when
supporting cascading replication.

Also handle the case when a standby doesn't have to follow any node.
Currently these are transient cases after master election and in future
this can happen when an user will be able to define a maximum number of
standbys.