### PR TITLE
keeper: add pg_rewind support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ stolon is a cloud native PostgreSQL manager for PostgreSQL high availability. It
 * Full cluster setup in minutes.
 * Easy [cluster admininistration](doc/stolonctl.md)
 * Automatic service discovery and dynamic reconfiguration (handles postgres and stolon processes changing their addresses).
+* Can use [pg_rewind](doc/pg_rewind.md) for fast instance resyncronization with current master.
 
 ## Architecture
 

--- a/doc/cluster_config.md
+++ b/doc/cluster_config.md
@@ -39,6 +39,8 @@ By default the cluster configuration is empty. For every empty field a default i
     "pg_repl_password": "password",
     "max_standbys_per_sender": 3,
     "synchronous_replication": false,
+    "init_with_multiple_keepers": false,
+    "use_pg_rewind": false,
     "pg_parameters": null
 }
 ```
@@ -51,6 +53,8 @@ By default the cluster configuration is empty. For every empty field a default i
 * pg_repl_password: (string) PostgreSQL replication password
 * max_standbys_per_sender: (uint) max number of standbys for every sender. A sender can be a master or another standby (with cascading replication).
 * synchronous_replication: (bool) use synchronous replication between the master and its standbys
+* init_with_multiple_keepers: (bool) Choose a random initial master when multiple keeper are registered. Used only at cluster initialization (empty clusterview).
+* use_pg_rewind: (bool) try to use pg_rewind for faster instance resyncronization.
 * pg_parameters: (map[string]string) a map containing the postgres server parameters and their values.
 
 

--- a/doc/pg_rewind.md
+++ b/doc/pg_rewind.md
@@ -1,0 +1,29 @@
+#  pg_rewind
+
+Stolon can use [pg_rewind](http://www.postgresql.org/docs/current/static/app-pgrewind.html) to speedup instance resynchronization (for example resyncing an old master or a slave ahead of the current master) without the need to copy all the new master data.
+
+## Enabling
+
+It can be enabled setting to true the cluster config option `use_pg_rewind` (disabled by default). So you should enable it in the cluster config:
+
+``` bash
+stolonctl --cluster-name=mycluster config patch '{ "use_pg_rewind" : true }'
+```
+
+This will also enable the `wal_log_hints` postgresql parameter. If previously `wal_log_hints` wasn't enabled you should restart the postgresql instances (you can do so restarting the `stolon-keeper`)
+
+pg_rewind needs to connect to the master database with a superuser role:
+* A superuser role (if not existing) needs to be created on the master database.
+* The superuser credentials need to be provided to the `stolon-keeper`.
+
+Actually only password authentication is supported. In future different authentication mechanism will be added.
+
+Actually to avoid security problems (superuser credential cannot be globally defined in the cluster config since actually it can be read by anyone accessing the cluster store) you have to set the superuser name and password when executing the `stolon-keeper`:
+* Exporting the `STKEEPER_PG_SU_USERNAME` and `STKEEPER_PG_SU_PASSWORD` environment variables (preferred since a process env variables can be read only by root or the stolon-keeper running user).
+* Providing the `--pg-su-username` and `--pg-su-password` options (discouraged since every user can read the password with a simple `ps`)
+
+In future there'll be an option to provide these credentials inside a configuration file.
+
+
+
+

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -32,6 +32,7 @@ const (
 	DefaultMaxStandbysPerSender    = 3
 	DefaultSynchronousReplication  = false
 	DefaultInitWithMultipleKeepers = false
+	DefaultUsePGRewind             = false
 )
 
 type NilConfig struct {
@@ -43,6 +44,7 @@ type NilConfig struct {
 	MaxStandbysPerSender    *uint              `json:"max_standbys_per_sender,omitempty"`
 	SynchronousReplication  *bool              `json:"synchronous_replication,omitempty"`
 	InitWithMultipleKeepers *bool              `json:"init_with_multiple_keepers,omitempty"`
+	UsePGRewind             *bool              `json:"use_pg_rewind,omitempty"`
 	PGParameters            *map[string]string `json:"pg_parameters,omitempty"`
 }
 
@@ -64,6 +66,8 @@ type Config struct {
 	SynchronousReplication bool
 	// Choose a random initial master when multiple keeper are registered
 	InitWithMultipleKeepers bool
+	// Whether to use pg_rewind
+	UsePGRewind bool
 	// Map of postgres parameters
 	PGParameters map[string]string
 }
@@ -134,6 +138,9 @@ func (c *NilConfig) Copy() *NilConfig {
 	}
 	if c.InitWithMultipleKeepers != nil {
 		nc.InitWithMultipleKeepers = BoolP(*c.InitWithMultipleKeepers)
+	}
+	if c.UsePGRewind != nil {
+		nc.UsePGRewind = BoolP(*c.UsePGRewind)
 	}
 	if c.PGParameters != nil {
 		nc.PGParameters = MapStringP(*c.PGParameters)
@@ -216,6 +223,9 @@ func (c *NilConfig) MergeDefaults() {
 	if c.InitWithMultipleKeepers == nil {
 		c.InitWithMultipleKeepers = BoolP(DefaultInitWithMultipleKeepers)
 	}
+	if c.UsePGRewind == nil {
+		c.UsePGRewind = BoolP(DefaultUsePGRewind)
+	}
 	if c.PGParameters == nil {
 		c.PGParameters = &map[string]string{}
 	}
@@ -233,6 +243,7 @@ func (c *NilConfig) ToConfig() *Config {
 		MaxStandbysPerSender:    *nc.MaxStandbysPerSender,
 		SynchronousReplication:  *nc.SynchronousReplication,
 		InitWithMultipleKeepers: *nc.InitWithMultipleKeepers,
+		UsePGRewind:             *nc.UsePGRewind,
 		PGParameters:            *nc.PGParameters,
 	}
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -370,6 +370,11 @@ func (tk *TestKeeper) IsMaster() (bool, error) {
 	return false, fmt.Errorf("no rows returned")
 }
 
+func (tk *TestKeeper) CreateSuperUser(username, password string) error {
+	_, err := tk.Exec(fmt.Sprintf(`create role "%s" with login superuser encrypted password '%s';`, username, password))
+	return err
+}
+
 func (tk *TestKeeper) WaitRole(r common.Role, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {


### PR DESCRIPTION
This patch adds pg_rewind support. By default it's disabled and can be
enabled setting the `use_pg_rewind` cluster config options to true.
Since pg_rewind needs to connect to the master instance with a superuser
role, the superuser credential needs to be provided (currently at
startup using environment variables or options (discouraged)) to all the
`stolon-keeper` processes. For security reason they cannot be provided
inside the cluster config.

It'll also work with synchronous replication (pg_rewind needs to connect
with `synchronous_commit` disabled at its session level).

Add related tests.

Add related documentation.