### PR TITLE
keeper: use ttl for store discovery

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -153,12 +153,15 @@ func (e *StoreManager) GetClusterView() (*cluster.ClusterView, *kvstore.KVPair, 
 	return cd.ClusterView, pair, nil
 }
 
-func (e *StoreManager) SetKeeperDiscoveryInfo(id string, ms *cluster.KeeperDiscoveryInfo) error {
+func (e *StoreManager) SetKeeperDiscoveryInfo(id string, ms *cluster.KeeperDiscoveryInfo, ttl time.Duration) error {
 	msj, err := json.Marshal(ms)
 	if err != nil {
 		return err
 	}
-	return e.store.Put(filepath.Join(e.clusterPath, keepersDiscoveryInfoDir, id), msj, nil)
+	if ttl < minTTL {
+		ttl = minTTL
+	}
+	return e.store.Put(filepath.Join(e.clusterPath, keepersDiscoveryInfoDir, id), msj, &kvstore.WriteOptions{TTL: ttl})
 }
 
 func (e *StoreManager) GetKeeperDiscoveryInfo(id string) (*cluster.KeeperDiscoveryInfo, bool, error) {


### PR DESCRIPTION
Instead of writing a persistent discoveryInfo key, use a ttl.
Now there's a dedicated goroutine, fired with a timer, that will update
the discoveryInfo (since the main loop can block for some time on some
operations and updating the discoveryInfo inside it can cause the key to
expire).