### PR TITLE
stolon: add --discovery-type option.

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -285,10 +285,6 @@ func (p *PostgresKeeper) usePGRewind() bool {
 }
 
 func (p *PostgresKeeper) publish() error {
-	if kubernetes.OnKubernetes() {
-		log.Infof("running under kubernetes. Not using store discovery")
-		return nil
-	}
 	discoveryInfo := &cluster.KeeperDiscoveryInfo{
 		ListenAddress: p.listenAddress,
 		Port:          p.port,
@@ -1051,6 +1047,10 @@ func keeper(cmd *cobra.Command, args []string) {
 	}
 
 	log.Infof("id: %s", id)
+
+	if kubernetes.OnKubernetes() {
+		log.Infof("running under kubernetes.")
+	}
 
 	stop := make(chan bool, 0)
 	end := make(chan error, 0)

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -15,9 +15,14 @@ In the [image](examples/kubernetes/image/docker) directory you'll find the Docke
 `sorintlab/stolon:master` is the one used by the kubernetes definitions in this example.
 For a more stable testing you can use `sorintlab/stolon:latest`
 
+### Keepers discovery
+
+When running inside a kubernetes cluster then sentinels will use the kubernetes APIs to discover keepers members. If, on your setup, this doesn't work (for example no api service certificates configured or https api serving disabled) you can disable it using the stolon-sentinel `--discovery-type=store` or exporting the `STSENTINEL_DISCOVERY_TYPE=store` environment variable (see the commented variable in the [stolon-sentinel](stolon-sentinel.yaml) replication controller definition.
+
 ## Cluster setup and tests
 
 These example points to a single node etcd cluster on `10.245.1.1:2379` without tls. You can change the ST${COMPONENT}_STORE_ENDPOINTS environment variables in the definitions to point to the right etcd cluster.
+
 
 ### Create the sentinel(s)
 

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -19,6 +19,9 @@ spec:
         env:
           - name: SENTINEL
             value: "true"
+          # Uncomment this if kubernetes discovery doesn't work on your kubernetes cluster (for example no api service certificates configured or https api serving disabled)
+          #- name: STSENTINEL_DISCOVERY_TYPE
+          #  value: "store"
           - name: STSENTINEL_CLUSTER_NAME
             value: "kube-stolon"
           - name: STSENTINEL_STORE_BACKEND


### PR DESCRIPTION
This option will let the user choose the discovery type (store or
kubernetes). By default it'll be detected.

The keeper will always publish its discoveryInfo to the store, it's up
to the sentinel to use it or not.