### PR TITLE
Setting the initial pgsql superuser password

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -59,6 +59,7 @@ type config struct {
 	keeperPort              string
 	keeperKubeLabelSelector string
 	initialClusterConfig    string
+	kubernetesNamespace     string
 	debug                   bool
 }
 
@@ -73,6 +74,7 @@ func init() {
 	cmdSentinel.PersistentFlags().StringVar(&cfg.keeperKubeLabelSelector, "keeper-kube-label-selector", "", "label selector for discoverying stolon-keeper(s) under kubernetes")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.keeperPort, "keeper-port", "5431", "stolon-keeper(s) listening port (used by kubernetes discovery)")
 	cmdSentinel.PersistentFlags().StringVar(&cfg.initialClusterConfig, "initial-cluster-config", "", "a file providing the initial cluster config, used only at cluster initialization, ignored if cluster is already initialized")
+	cmdSentinel.PersistentFlags().StringVar(&cfg.kubernetesNamespace, "kubernetes-namespace", "default", "the Kubernetes namespace stolon is deployed under")
 	cmdSentinel.PersistentFlags().BoolVar(&cfg.debug, "debug", false, "enable debug logging")
 }
 
@@ -272,7 +274,7 @@ func (s *Sentinel) getKubernetesPodsIPs(ctx context.Context) ([]string, error) {
 	}
 	host := os.Getenv("KUBERNETES_SERVICE_HOST")
 	port := os.Getenv("KUBERNETES_SERVICE_PORT")
-	u, err := url.Parse(fmt.Sprintf("https://%s:%s/api/v1/namespaces/default/pods", host, port))
+	u, err := url.Parse(fmt.Sprintf("https://%s:%s/api/v1/namespaces/%s/pods", host, port, cfg.kubernetesNamespace))
 	if err != nil {
 		return nil, err
 	}

--- a/examples/kubernetes/secret.yaml
+++ b/examples/kubernetes/secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+    name: stolon
+type: Opaque
+data:
+    password: cGFzc3dvcmQxCg==

--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -29,12 +29,21 @@ spec:
             # Enable debugging
           - name: STKEEPER_DEBUG
             value: "true"
+          - name: STKEEPER_INITIAL_PG_SU_USERNAME
+            value: "stolon"
+          - name: STKEEPER_INITIAL_PG_SU_PASSWORD_FILE
+            value: "/etc/secrets/stolon/password"
         ports:
           - containerPort: 5431
           - containerPort: 5432
         volumeMounts:
         - mountPath: /stolon-data
           name: data
+        - mountPath: /etc/secrets/stolon
+          name: stolon
       volumes:
         - name: data
           emptyDir: {}
+        - name: stolon
+          secret:
+            secretName: stolon

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -30,5 +30,7 @@ spec:
             # Enable debugging
           - name: STSENTINEL_DEBUG
             value: "true"
+          - name: STSENTINEL_KUBERNETES_NAMESPACE
+            value: "default"
         ports:
           - containerPort: 6431

--- a/pkg/postgresql/utils.go
+++ b/pkg/postgresql/utils.go
@@ -89,6 +89,17 @@ func CheckDBStatus(ctx context.Context, connString string) error {
 	return nil
 }
 
+func SetInitialPassword(ctx context.Context, connString, superuser, initialPassword string) error {
+	db, err := sql.Open("postgres", connString)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	_, err = Exec(ctx, db, fmt.Sprintf(`alter user %s with password '%s';`, superuser, initialPassword))
+	return err
+}
+
 func CreateReplRole(ctx context.Context, connString, replUser, replPassword string) error {
 	db, err := sql.Open("postgres", connString)
 	if err != nil {


### PR DESCRIPTION
* Adds initial-su-username and initial-su-password-secret-file parameters. If these are set, stolon will set the proper password for the initial superuser when postgresql is first initialized.
* Adds an example secret and usage to the Kubernetes examples.
* Adds support for specifying a namespace to sentinel. This allows stolon to be ran outside of the "default" namespace.