### PR TITLE
keeper: refactor user and password management and options

### DIFF
--- a/doc/cluster_config.md
+++ b/doc/cluster_config.md
@@ -35,8 +35,6 @@ By default the cluster configuration is empty. For every empty field a default i
     "request_timeout": "10s",
     "sleep_interval": "5s",
     "keeper_fail_interval": "20s",
-    "pg_repl_user": "username",
-    "pg_repl_password": "password",
     "max_standbys_per_sender": 3,
     "synchronous_replication": false,
     "init_with_multiple_keepers": false,
@@ -49,8 +47,6 @@ By default the cluster configuration is empty. For every empty field a default i
 * request_timeout: (duration) time after which any request (keepers checks from sentinel etc...) will fail.
 * sleep_interval: (duration) interval to wait before next check (for every component: keeper, sentinel, proxy).
 * keeper_fail_interval: (duration) interval after the first fail to declare a keeper as not healthy.
-* pg_repl_user: (string) PostgreSQL replication username
-* pg_repl_password: (string) PostgreSQL replication password
 * max_standbys_per_sender: (uint) max number of standbys for every sender. A sender can be a master or another standby (with cascading replication).
 * synchronous_replication: (bool) use synchronous replication between the master and its standbys
 * init_with_multiple_keepers: (bool) Choose a random initial master when multiple keeper are registered. Used only at cluster initialization (empty clusterview).

--- a/doc/pg_rewind.md
+++ b/doc/pg_rewind.md
@@ -12,17 +12,15 @@ stolonctl --cluster-name=mycluster config patch '{ "use_pg_rewind" : true }'
 
 This will also enable the `wal_log_hints` postgresql parameter. If previously `wal_log_hints` wasn't enabled you should restart the postgresql instances (you can do so restarting the `stolon-keeper`)
 
-pg_rewind needs to connect to the master database with a superuser role:
-* A superuser role (if not existing) needs to be created on the master database.
-* The superuser credentials need to be provided to the `stolon-keeper`.
-
+pg_rewind needs to connect to the master database with a superuser role.
 Actually only password authentication is supported. In future different authentication mechanism will be added.
 
-Actually to avoid security problems (superuser credential cannot be globally defined in the cluster config since actually it can be read by anyone accessing the cluster store) you have to set the superuser name and password when executing the `stolon-keeper`:
-* Exporting the `STKEEPER_PG_SU_USERNAME` and `STKEEPER_PG_SU_PASSWORD` environment variables (preferred since a process env variables can be read only by root or the stolon-keeper running user).
-* Providing the `--pg-su-username` and `--pg-su-password` options (discouraged since every user can read the password with a simple `ps`)
+* It'll use the superuser role provided with `--pg-su-username` (if not specified it'll default to the os user name running the stolon-keeper). This superuser role (if not existing) needs to be created on the master database.
+* The superuser credentials need to be provided to the `stolon-keeper`.
 
-In future there'll be an option to provide these credentials inside a configuration file.
+Actually to avoid security problems (superuser credential cannot be globally defined in the cluster config since actually it can be read by anyone accessing the cluster store) you have to set the superuser name and password when executing the `stolon-keeper`:
+* Providing the `--pg-su-username` and `--pg-su-passwordfile` (preferred) or `--pg-su-password` options (discouraged since every user accessing the system can read the password with a simple `ps`)
+* Exporting the `STKEEPER_PG_SU_USERNAME` and `STKEEPER_PG_SU_PASSWORD` environment variables.
 
 
 

--- a/doc/simplecluster.md
+++ b/doc/simplecluster.md
@@ -23,7 +23,7 @@ sentinel: sentinel leadership acquired
 ### Launch first keeper
 
 ```
-./bin/stolon-keeper --data-dir data/postgres0 --id postgres0 --cluster-name stolon-cluster
+./bin/stolon-keeper --data-dir data/postgres0 --id postgres0 --cluster-name stolon-cluster --pg-repl-username=repluser --pg-repl-password=replpassword
 ```
 
 This will start a stolon keeper with id `postgres0` listening by default on localhost:5431, it will setup and initialize a postgres instance inside `data/postgres0/postgres/`
@@ -94,7 +94,7 @@ postgres=# select * from test;
 ### Start another keeper:
 
 ```
-./bin/stolon-keeper --data-dir data/postgres1 --id postgres1 --cluster-name stolon-cluster --port 5433 --pg-port 5435
+./bin/stolon-keeper --data-dir data/postgres1 --id postgres1 --cluster-name stolon-cluster --pg-repl-username=repluser --pg-repl-password=replpassword --port 5433 --pg-port 5435 
 ```
 
 This instance will start replicating from the master (postgres0)

--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -27,12 +27,17 @@ spec:
           - name: STKEEPER_STORE_ENDPOINTS
             value: "10.245.1.1:2379"
             # Enable debugging
+          - name: STKEEPER_PG_REPL_USERNAME
+            value: "repluser"
+            # Or use a password file like in the below supersuser password
+          - name: STKEEPER_PG_REPL_PASSWORD
+            value: "replpassword"
+          - name: STKEEPER_PG_SU_USERNAME
+            value: "stolon"
+          - name: STKEEPER_PG_SU_PASSWORDFILE
+            value: "/etc/secrets/stolon/password"
           - name: STKEEPER_DEBUG
             value: "true"
-          - name: STKEEPER_INITIAL_PG_SU_USERNAME
-            value: "stolon"
-          - name: STKEEPER_INITIAL_PG_SU_PASSWORD_FILE
-            value: "/etc/secrets/stolon/password"
         ports:
           - containerPort: 5431
           - containerPort: 5432

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -27,8 +27,6 @@ const (
 	DefaultRequestTimeout          = 10 * time.Second
 	DefaultSleepInterval           = 5 * time.Second
 	DefaultKeeperFailInterval      = 20 * time.Second
-	DefaultPGReplUser              = "repluser"
-	DefaultPGReplPassword          = "replpassword"
 	DefaultMaxStandbysPerSender    = 3
 	DefaultSynchronousReplication  = false
 	DefaultInitWithMultipleKeepers = false
@@ -39,8 +37,6 @@ type NilConfig struct {
 	RequestTimeout          *Duration          `json:"request_timeout,omitempty"`
 	SleepInterval           *Duration          `json:"sleep_interval,omitempty"`
 	KeeperFailInterval      *Duration          `json:"keeper_fail_interval,omitempty"`
-	PGReplUser              *string            `json:"pg_repl_user,omitempty"`
-	PGReplPassword          *string            `json:"pg_repl_password,omitempty"`
 	MaxStandbysPerSender    *uint              `json:"max_standbys_per_sender,omitempty"`
 	SynchronousReplication  *bool              `json:"synchronous_replication,omitempty"`
 	InitWithMultipleKeepers *bool              `json:"init_with_multiple_keepers,omitempty"`
@@ -55,10 +51,6 @@ type Config struct {
 	SleepInterval time.Duration
 	// Interval after the first fail to declare a keeper as not healthy.
 	KeeperFailInterval time.Duration
-	// PostgreSQL replication username
-	PGReplUser string
-	// PostgreSQL replication password
-	PGReplPassword string
 	// Max number of standbys for every sender. A sender can be a master or
 	// another standby (with cascading replication).
 	MaxStandbysPerSender uint
@@ -124,12 +116,6 @@ func (c *NilConfig) Copy() *NilConfig {
 	if c.KeeperFailInterval != nil {
 		nc.KeeperFailInterval = DurationP(*c.KeeperFailInterval)
 	}
-	if c.PGReplUser != nil {
-		nc.PGReplUser = StringP(*c.PGReplUser)
-	}
-	if c.PGReplPassword != nil {
-		nc.PGReplPassword = StringP(*c.PGReplPassword)
-	}
 	if c.MaxStandbysPerSender != nil {
 		nc.MaxStandbysPerSender = UintP(*c.MaxStandbysPerSender)
 	}
@@ -186,12 +172,6 @@ func (c *NilConfig) Validate() error {
 	if c.KeeperFailInterval != nil && (*c.KeeperFailInterval).Duration < 0 {
 		return fmt.Errorf("keeper_fail_interval must be positive")
 	}
-	if c.PGReplUser != nil && *c.PGReplUser == "" {
-		return fmt.Errorf("pg_repl_user cannot be empty")
-	}
-	if c.PGReplPassword != nil && *c.PGReplPassword == "" {
-		return fmt.Errorf("pg_repl_password cannot be empty")
-	}
 	if c.MaxStandbysPerSender != nil && *c.MaxStandbysPerSender < 1 {
 		return fmt.Errorf("max_standbys_per_sender must be at least 1")
 	}
@@ -207,12 +187,6 @@ func (c *NilConfig) MergeDefaults() {
 	}
 	if c.KeeperFailInterval == nil {
 		c.KeeperFailInterval = &Duration{DefaultKeeperFailInterval}
-	}
-	if c.PGReplUser == nil {
-		c.PGReplUser = StringP(DefaultPGReplUser)
-	}
-	if c.PGReplPassword == nil {
-		c.PGReplPassword = StringP(DefaultPGReplPassword)
 	}
 	if c.MaxStandbysPerSender == nil {
 		c.MaxStandbysPerSender = UintP(DefaultMaxStandbysPerSender)
@@ -238,8 +212,6 @@ func (c *NilConfig) ToConfig() *Config {
 		RequestTimeout:          (*nc.RequestTimeout).Duration,
 		SleepInterval:           (*nc.SleepInterval).Duration,
 		KeeperFailInterval:      (*nc.KeeperFailInterval).Duration,
-		PGReplUser:              *nc.PGReplUser,
-		PGReplPassword:          *nc.PGReplPassword,
 		MaxStandbysPerSender:    *nc.MaxStandbysPerSender,
 		SynchronousReplication:  *nc.SynchronousReplication,
 		InitWithMultipleKeepers: *nc.InitWithMultipleKeepers,

--- a/pkg/cluster/config_test.go
+++ b/pkg/cluster/config_test.go
@@ -67,23 +67,13 @@ func TestParseConfig(t *testing.T) {
 			err: fmt.Errorf("config validation failed: keeper_fail_interval must be positive"),
 		},
 		{
-			in:  `{ "pg_repl_user": "" }`,
-			cfg: nil,
-			err: fmt.Errorf("config validation failed: pg_repl_user cannot be empty"),
-		},
-		{
-			in:  `{ "pg_repl_password": "" }`,
-			cfg: nil,
-			err: fmt.Errorf("config validation failed: pg_repl_password cannot be empty"),
-		},
-		{
 			in:  `{ "max_standbys_per_sender": 0 }`,
 			cfg: nil,
 			err: fmt.Errorf("config validation failed: max_standbys_per_sender must be at least 1"),
 		},
 		// All options defined
 		{
-			in: `{ "request_timeout": "10s", "sleep_interval": "10s", "keeper_fail_interval": "100s", "pg_repl_user": "username", "pg_repl_password": "password", "max_standbys_per_sender": 5, "synchronous_replication": true, "init_with_multiple_keepers": true,
+			in: `{ "request_timeout": "10s", "sleep_interval": "10s", "keeper_fail_interval": "100s", "max_standbys_per_sender": 5, "synchronous_replication": true, "init_with_multiple_keepers": true,
 			       "pg_parameters": {
 			         "param01": "value01"
 				}
@@ -92,8 +82,6 @@ func TestParseConfig(t *testing.T) {
 				RequestTimeout:          &Duration{10 * time.Second},
 				SleepInterval:           &Duration{10 * time.Second},
 				KeeperFailInterval:      &Duration{100 * time.Second},
-				PGReplUser:              StringP("username"),
-				PGReplPassword:          StringP("password"),
 				MaxStandbysPerSender:    UintP(5),
 				SynchronousReplication:  BoolP(true),
 				InitWithMultipleKeepers: BoolP(true),

--- a/pkg/postgresql/utils.go
+++ b/pkg/postgresql/utils.go
@@ -89,25 +89,36 @@ func CheckDBStatus(ctx context.Context, connString string) error {
 	return nil
 }
 
-func SetInitialPassword(ctx context.Context, connString, superuser, initialPassword string) error {
+func SetPassword(ctx context.Context, connString, username, password string) error {
 	db, err := sql.Open("postgres", connString)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
-	_, err = Exec(ctx, db, fmt.Sprintf(`alter user %s with password '%s';`, superuser, initialPassword))
+	_, err = Exec(ctx, db, fmt.Sprintf(`alter role %s with password '%s';`, username, password))
 	return err
 }
 
-func CreateReplRole(ctx context.Context, connString, replUser, replPassword string) error {
+func CreateRole(ctx context.Context, connString string, roles []string, username, password string) error {
 	db, err := sql.Open("postgres", connString)
 	if err != nil {
 		return err
 	}
 	defer db.Close()
 
-	_, err = Exec(ctx, db, fmt.Sprintf(`create role "%s" with login replication encrypted password '%s';`, replUser, replPassword))
+	_, err = Exec(ctx, db, fmt.Sprintf(`create role "%s" with login replication encrypted password '%s';`, username, password))
+	return err
+}
+
+func AlterRole(ctx context.Context, connString string, roles []string, username, password string) error {
+	db, err := sql.Open("postgres", connString)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	_, err = Exec(ctx, db, fmt.Sprintf(`alter role "%s" with login replication encrypted password '%s';`, username, password))
 	return err
 }
 

--- a/pkg/util/user.go
+++ b/pkg/util/user.go
@@ -1,0 +1,35 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+)
+
+func GetUser() (string, error) {
+	u, err := user.Current()
+	if err == nil {
+		return u.Username, nil
+	}
+
+	name := os.Getenv("USER")
+	if name != "" {
+		return name, nil
+	}
+
+	return "", fmt.Errorf("cannot detect current user")
+}

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -71,7 +71,7 @@ func TestServerParameters(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
+	tk, err := NewTestKeeper(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -30,8 +30,10 @@ import (
 )
 
 const (
-	PGSUUsername = "stolon_superuser"
-	PGSUPassword = "stolon_superuser"
+	pgReplUsername = "stolon_repluser"
+	pgReplPassword = "stolon_replpassword"
+	pgSUUsername   = "stolon_superuser"
+	pgSUPassword   = "stolon_superuserpassword"
 )
 
 func setupStore(t *testing.T, dir string) *TestStore {
@@ -89,7 +91,7 @@ func TestInitWithMultipleKeepers(t *testing.T) {
 
 	// Start 3 keepers
 	for i := uint8(0); i < 3; i++ {
-		tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
+		tk, err := NewTestKeeper(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -152,7 +154,7 @@ func setupServers(t *testing.T, clusterName, dir string, numKeepers, numSentinel
 	tks := []*TestKeeper{}
 	tss := []*TestSentinel{}
 
-	tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints, "--pg-su-username="+PGSUUsername, "--pg-su-password="+PGSUPassword)
+	tk, err := NewTestKeeper(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -187,14 +189,9 @@ func setupServers(t *testing.T, clusterName, dir string, numKeepers, numSentinel
 		t.Fatalf("expected master %q in cluster view", tk.id)
 	}
 
-	// Create superuser (needed for pg_rewind)
-	if err := tk.CreateSuperUser(PGSUUsername, PGSUPassword); err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-
 	// Start other keepers
 	for i := uint8(1); i < numKeepers; i++ {
-		tk, err := NewTestKeeper(t, dir, clusterName, tstore.storeBackend, storeEndpoints, "--pg-su-username="+PGSUUsername, "--pg-su-password="+PGSUPassword)
+		tk, err := NewTestKeeper(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -691,7 +688,7 @@ func TestMasterChangedAddress(t *testing.T) {
 	t.Logf("Restarting current master keeper %q with different addresses", master.id)
 	master.Stop()
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
-	master, err = NewTestKeeperWithID(t, dir, master.id, clusterName, tstore.storeBackend, storeEndpoints)
+	master, err = NewTestKeeperWithID(t, dir, master.id, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
 	tks = append(tks, master)
 
 	if err := master.Start(); err != nil {


### PR DESCRIPTION
This patch tries to unify the user and password management.

* Since the replication username and password are also sensitive, remove
them from the clusterconfig and require the user to provide them as
keeper options. Obviously they need to have the same values for all the
keepers (`--pg-repl-username`, `--pg-repl-password[file]`).

* Use `--pg-su-username` and `pg-su-password[file]` options for all the
superuser required accesses:
 * to setup the superuser at db initialization time (previously it was
directly used the os username running the keepers, now it defaults to
this if not specified)
 * as credentials used by the keeper for superuser access to the postgres
instance.
 * as credentials for pg_rewind.

* The replication and superuser password options can be provided as
parameters (`--pg-su-password`, `--pg-repl-password`) or as a password
file (`--pg-su-passwordfile`, `--pg-repl-passwordfile`)