### PR TITLE
stolon: Add travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.5.4
+  - 1.6.3
+  - 1.7
+
+env:
+  - TARGET=amd64
+  - TARGET=arm64
+
+install:
+  -
+
+script:
+        ./test


### PR DESCRIPTION
Add travis CI to just test compilation and unit tests (no integration tests)
with multiple go versions (1.5, 1.6 and 1.7) and architectures (amd64 and
arm64).