### PR TITLE
Reproduce readlink -f behavior on osx

### DIFF
--- a/build
+++ b/build
@@ -2,7 +2,28 @@
 
 set -e
 
-BASEDIR=$(readlink -f $(dirname $0))
+# Cross compatibility with osx
+# origin source: https://github.com/kubernetes/kubernetes/blob/master/hack/lib/init.sh#L102
+function readlinkdashf() {
+	# run in a subshell for simpler 'cd'
+  (
+    if [[ -d "$1" ]]; then # This also catch symlinks to dirs.
+      cd "$1"
+      pwd -P
+    else
+      cd $(dirname "$1")
+      local f
+      f=$(basename "$1")
+      if [[ -L "$f" ]]; then
+        readlink "$f"
+      else
+        echo "$(pwd -P)/${f}"
+      fi
+    fi
+  )
+}
+
+BASEDIR=$(readlinkdashf $(dirname $0))
 BINDIR=${BASEDIR}/bin
 
 if [ $PWD != $BASEDIR ]; then
@@ -80,4 +101,3 @@ rm -f ${DOCKERIMAGE}/bin/*
 for cmd in stolon-keeper stolon-sentinel stolon-proxy stolonctl; do
 	cp ${BINDIR}/${cmd} ${DOCKERIMAGE}/bin/
 done
-


### PR DESCRIPTION
The script failed to run on OSx because `readlink -f` is not supported by Darwin system.
