### PR TITLE
CI: no need for external go anymore

### DIFF
--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -4,17 +4,6 @@ set -e
 
 # Setup for semaphore ci
 
-function switch_to_go16() {
-	sudo ln -fs /usr/local/golang/1.6.0/go/bin/go /usr/local/bin/go
-	# remove other Go version from path
-	export PATH=`echo $PATH | sed -e 's|:/usr/local/golang/.*/go/bin||'`
-	# setup GOROOT
-	export GOROOT="/usr/local/golang/1.6.0/go"
-	# add new go installation to PATH
-	export PATH="$PATH:/usr/local/golang/1.6.0/go/bin"
-}
-
-
 if [ "${CI}" != "true" -o "${SEMAPHORE}" != "true" ]; then
 	echo "not on semaphoreci"
 	exit 1
@@ -40,16 +29,6 @@ sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
 sudo apt-get -y install postgresql-9.5
-
-# Install go 1.6
-# TODO(sgotti) remove when semaphore image will provide it
-curl -L  https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz -o /tmp/go1.6.linux-amd64.tar.gz
-sudo mkdir /usr/local/golang/1.6.0
-pushd /usr/local/golang/1.6.0
-sudo tar xvfz /tmp/go1.6.linux-amd64.tar.gz
-popd
-
-switch_to_go16
 
 # Precompile stdlib with cgo disable to speedup builds
 sudo -E CGO_ENABLED=0 go install -a -installsuffix cgo std


### PR DESCRIPTION
Now semaphore provides go1.7 so no need to do an external go installation.