### PR TITLE
cluster: Add FormatVersion field to clusterdata.

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -741,6 +741,12 @@ func (s *Sentinel) clusterSentinelCheck(pctx context.Context) {
 		log.Errorf("error retrieving cluster data: %v", err)
 		return
 	}
+	if cd != nil {
+		if cd.FormatVersion != cluster.CurrentCDFormatVersion {
+			log.Errorf("unsupported clusterdata format version %d", cd.FormatVersion)
+			return
+		}
+	}
 
 	var cv *cluster.ClusterView
 	var keepersState cluster.KeepersState

--- a/cmd/stolonctl/config_get.go
+++ b/cmd/stolonctl/config_get.go
@@ -38,10 +38,17 @@ func init() {
 }
 
 func getConfig(e *store.StoreManager) (*cluster.NilConfig, error) {
-	cv, _, err := e.GetClusterView()
+	cd, _, err := e.GetClusterData()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get clusterview: %v", err)
+		return nil, fmt.Errorf("cannot get clusterdata: %v", err)
 	}
+	if cd == nil {
+		return nil, fmt.Errorf("nil cluster data: %v", err)
+	}
+	if cd.FormatVersion != cluster.CurrentCDFormatVersion {
+		return nil, fmt.Errorf("unsupported clusterdata format version %d", cd.FormatVersion)
+	}
+	cv := cd.ClusterView
 	if cv == nil {
 		return nil, fmt.Errorf("no clusterview available")
 	}

--- a/pkg/cluster/clusterview.go
+++ b/pkg/cluster/clusterview.go
@@ -21,6 +21,10 @@ import (
 	"time"
 )
 
+const (
+	CurrentCDFormatVersion uint64 = 0
+)
+
 type KeepersState map[string]*KeeperState
 
 func (kss KeepersState) SortedKeys() []string {
@@ -221,6 +225,12 @@ func (cv *ClusterView) GetFollowersIDs(id string) []string {
 
 // A struct containing the KeepersState and the ClusterView since they need to be in sync
 type ClusterData struct {
+	// ClusterData format version. Used to detect incompatible
+	// version and do upgrade. Needs to be bumped when a non
+	// backward compatible change is done to the other struct
+	// members.
+	FormatVersion uint64
+
 	KeepersState KeepersState
 	ClusterView  *ClusterView
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -137,22 +137,6 @@ func (e *StoreManager) GetClusterData() (*cluster.ClusterData, *kvstore.KVPair, 
 	return cd, pair, nil
 }
 
-func (e *StoreManager) GetKeepersState() (cluster.KeepersState, *kvstore.KVPair, error) {
-	cd, pair, err := e.GetClusterData()
-	if err != nil || cd == nil {
-		return nil, pair, err
-	}
-	return cd.KeepersState, pair, nil
-}
-
-func (e *StoreManager) GetClusterView() (*cluster.ClusterView, *kvstore.KVPair, error) {
-	cd, pair, err := e.GetClusterData()
-	if err != nil || cd == nil {
-		return nil, pair, err
-	}
-	return cd.ClusterView, pair, nil
-}
-
 func (e *StoreManager) SetKeeperDiscoveryInfo(id string, ms *cluster.KeeperDiscoveryInfo, ttl time.Duration) error {
 	msj, err := json.Marshal(ms)
 	if err != nil {

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -74,7 +74,6 @@ func TestInit(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	t.Logf("database is up")
-
 }
 
 func TestInitUsers(t *testing.T) {
@@ -243,10 +242,11 @@ func TestInitialClusterConfig(t *testing.T) {
 		t.Fatal("expected cluster initialized")
 	}
 
-	cv, _, err := e.GetClusterView()
+	cd, _, err := e.GetClusterData()
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
+	cv := cd.ClusterView
 	if !*cv.Config.SynchronousReplication {
 		t.Fatal("expected cluster config with SynchronousReplication enabled")
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -744,10 +744,12 @@ func (ts *TestStore) WaitDown(timeout time.Duration) error {
 func WaitClusterViewWithMaster(e *store.StoreManager, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cv, _, err := e.GetClusterView()
-		if err != nil {
+		var cv *cluster.ClusterView
+		cd, _, err := e.GetClusterData()
+		if err != nil || cd == nil {
 			goto end
 		}
+		cv = cd.ClusterView
 		if cv != nil {
 			if cv.Master != "" {
 				return nil
@@ -762,10 +764,12 @@ func WaitClusterViewWithMaster(e *store.StoreManager, timeout time.Duration) err
 func WaitClusterViewMaster(master string, e *store.StoreManager, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cv, _, err := e.GetClusterView()
-		if err != nil {
+		var cv *cluster.ClusterView
+		cd, _, err := e.GetClusterData()
+		if err != nil || cd == nil {
 			goto end
 		}
+		cv = cd.ClusterView
 		if cv != nil {
 			if cv.Master == master {
 				return nil
@@ -780,10 +784,12 @@ func WaitClusterViewMaster(master string, e *store.StoreManager, timeout time.Du
 func WaitClusterInitialized(e *store.StoreManager, timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {
-		cv, _, err := e.GetClusterView()
-		if err != nil {
+		var cv *cluster.ClusterView
+		cd, _, err := e.GetClusterData()
+		if err != nil || cd == nil {
 			goto end
 		}
+		cv = cd.ClusterView
 		if cv != nil {
 			if cv.Version > 0 {
 				return nil


### PR DESCRIPTION
This field (now with value 0 to be compatible with the current clusterdata that
doesn't have this field) will be used to be able to do and detect backward
incompatible format changes.