### PR TITLE
keeper: prefix replication slot names.

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -411,7 +411,7 @@ func (p *Manager) WriteConf() error {
 	return nil
 }
 
-func (p *Manager) WriteRecoveryConf(followedConnParams ConnParams) error {
+func (p *Manager) WriteRecoveryConf(followedConnParams ConnParams, replSlotName string) error {
 	f, err := ioutil.TempFile(p.dataDir, "recovery.conf")
 	if err != nil {
 		return err
@@ -419,7 +419,9 @@ func (p *Manager) WriteRecoveryConf(followedConnParams ConnParams) error {
 	defer f.Close()
 
 	f.WriteString("standby_mode = 'on'\n")
-	f.WriteString(fmt.Sprintf("primary_slot_name = '%s'\n", p.name))
+	if replSlotName != "" {
+		f.WriteString(fmt.Sprintf("primary_slot_name = '%s'\n", replSlotName))
+	}
 	f.WriteString("recovery_target_timeline = 'latest'\n")
 
 	if followedConnParams != nil {


### PR DESCRIPTION
Add a prefix to stolon managed replication slot names so we can filter out
other replication slots.

This can permit an user to add its own replication slots (for example for
external standbys). Before this patch this wasn't possible since the keeper
would have removed them.