### PR TITLE
postgres: update pg_hba.conf handling

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -174,12 +174,12 @@ func (p *PostgresKeeper) getReplConnParams(keeperState *cluster.KeeperState) pg.
 
 func (p *PostgresKeeper) getLocalConnParams() pg.ConnParams {
 	return pg.ConnParams{
-		"user": p.pgSUUsername,
-		// Do not set password since we assume that pg_hba.conf trusts local users
-		"host":    "localhost",
-		"port":    p.pgPort,
-		"dbname":  "postgres",
-		"sslmode": "disable",
+		"user":     p.pgSUUsername,
+		"password": p.pgSUPassword,
+		"host":     "localhost",
+		"port":     p.pgPort,
+		"dbname":   "postgres",
+		"sslmode":  "disable",
 	}
 }
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -180,11 +180,12 @@ func NewTestKeeperWithID(t *testing.T, dir, id, clusterName, pgSUUsername, pgSUP
 	args = append(args, a...)
 
 	connParams := pg.ConnParams{
-		"user":    pgSUUsername,
-		"host":    pgListenAddress,
-		"port":    pgPort,
-		"dbname":  "postgres",
-		"sslmode": "disable",
+		"user":     pgSUUsername,
+		"password": pgSUPassword,
+		"host":     pgListenAddress,
+		"port":     pgPort,
+		"dbname":   "postgres",
+		"sslmode":  "disable",
 	}
 
 	connString := connParams.ConnString()


### PR DESCRIPTION
Always overwrite (instead of appending) pg_hba.conf.
This also removes default entries created by initdb where local users
where trusted.