### PR TITLE
proxy: Don't report listen address

### DIFF
--- a/cmd/proxy/proxy.go
+++ b/cmd/proxy/proxy.go
@@ -143,8 +143,6 @@ func (c *ClusterChecker) sendPollonConfData(confData pollon.ConfData) {
 func (c *ClusterChecker) SetProxyInfo(e *store.StoreManager, uid string, generation int64, ttl time.Duration) error {
 	proxyInfo := &cluster.ProxyInfo{
 		UID:             c.id,
-		ListenAddress:   c.listenAddress,
-		Port:            c.port,
 		ProxyUID:        uid,
 		ProxyGeneration: generation,
 	}

--- a/cmd/stolonctl/status.go
+++ b/cmd/stolonctl/status.go
@@ -133,9 +133,9 @@ func status(cmd *cobra.Command, args []string) {
 		stdout("No active proxies")
 	} else {
 		sort.Sort(proxiesInfo)
-		fmt.Fprintf(tabOut, "ID\tLISTENADDRESS\tCV VERSION\n")
+		fmt.Fprintf(tabOut, "ID\n")
 		for _, pi := range proxiesInfo {
-			fmt.Fprintf(tabOut, "%s\t%s:%s\t%d\n", pi.UID, pi.ListenAddress, pi.Port, pi.ProxyGeneration)
+			fmt.Fprintf(tabOut, "%s\n", pi.UID)
 			tabOut.Flush()
 		}
 	}

--- a/doc/stolonctl.md
+++ b/doc/stolonctl.md
@@ -27,8 +27,8 @@ ID              LEADER
 
 === Active proxies ===
 
-ID              LISTENADDRESS   CV VERSION
-fc6b8f04        127.0.0.1:25432 43
+ID
+fc6b8f04
 
 === Keepers ===
 

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -108,8 +108,6 @@ func (p ProxiesInfo) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 type ProxyInfo struct {
 	UID             string
-	ListenAddress   string
-	Port            string
 	ProxyUID        string
 	ProxyGeneration int64
 }


### PR DESCRIPTION
Reporting proxy listen address is not useful since the proxy may listen
on INADDR_ANY.