### PR TITLE
keeper: improve handling of previous postgresql.conf

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -96,8 +96,9 @@ const (
 type DBInitMode string
 
 const (
-	// No db initialization
 	DBInitModeNone DBInitMode = "none"
+	// Use existing db cluster data
+	DBInitModeExisting DBInitMode = "existing"
 	// Initialize a db starting from a freshly initialized database cluster
 	DBInitModeNew DBInitMode = "new"
 	// Initialize a db doing a point in time recovery.

--- a/test
+++ b/test
@@ -96,6 +96,7 @@ if [ -n "$INTEGRATION" ]; then
 	export STKEEPER_BIN=${BINDIR}/stolon-keeper
 	export STSENTINEL_BIN=${BINDIR}/stolon-sentinel
 	export STPROXY_BIN=${BINDIR}/stolon-proxy
+	export STCTL_BIN=${BINDIR}/stolonctl
 	if [ "${STOLON_TEST_STORE_BACKEND}" == "etcd" ]; then
 		if [ -z ${ETCD_BIN} ]; then
 			if [ -z $(which etcd) ]; then

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -168,7 +168,7 @@ func TestPITR(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	if err := WaitClusterPhaseNormal(e, 60*time.Second); err != nil {
+	if err := WaitClusterPhase(e, cluster.ClusterPhaseNormal, 60*time.Second); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	_, err = WaitClusterDataWithMaster(e, 30*time.Second)


### PR DESCRIPTION
Don't move previous postgresql.conf but start instance with a temporary
config file.

Save locally init parameters so they can be restored if the keeper is
restarted before the sentinel has moved the cluster status to normal
phase.

Use pg_file_settings when available (pg >= 9.5) to retrieve pg
parameters.

Improve and add tests.