### PR TITLE
sentinel: make old master re-electable.

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -732,9 +732,8 @@ func (s *Sentinel) updateCluster(cd *cluster.ClusterData) (*cluster.ClusterData,
 
 		// New master elected
 		if curMasterDBUID != wantedMasterDBUID {
-			// Set the old master to an undefined role (the keeper will do nothing when role is RoleUndefined)
+			// maintain the current role, remove followers
 			oldMasterdb := newcd.DBs[curMasterDBUID]
-			oldMasterdb.Spec.Role = common.RoleUndefined
 			oldMasterdb.Spec.Followers = []string{}
 
 			newcd.Cluster.Status.Master = wantedMasterDBUID

--- a/cmd/sentinel/sentinel_test.go
+++ b/cmd/sentinel/sentinel_test.go
@@ -613,7 +613,7 @@ func TestUpdateCluster(t *testing.T) {
 						ChangeTime: time.Time{},
 						Spec: &cluster.DBSpec{
 							KeeperUID: "keeper01",
-							Role:      common.RoleUndefined,
+							Role:      common.RoleMaster,
 							Followers: []string{},
 						},
 						Status: cluster.DBStatus{
@@ -1026,7 +1026,7 @@ func TestUpdateCluster(t *testing.T) {
 						ChangeTime: time.Time{},
 						Spec: &cluster.DBSpec{
 							KeeperUID: "keeper01",
-							Role:      common.RoleUndefined,
+							Role:      common.RoleMaster,
 							Followers: []string{},
 						},
 						Status: cluster.DBStatus{


### PR DESCRIPTION
Keep the failed master role to Master so the keeper will keep
the postgres started and it can be reelected when coming back if the
other standby(s) fails to become master.

Add a test for this case.