### PR TITLE
keeper: handle pg_rewind wrongly considering dbs as not forked

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -518,9 +518,11 @@ func (p *Manager) SyncFromFollowedPGRewind(followedConnParams ConnParams, passwo
 	cmd := exec.Command(name, "--debug", "-D", p.dataDir, "--source-server="+followedConnString)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSFILE=%s", pgpass.Name()))
 	log.Debug("execing cmd", zap.Object("cmd", cmd))
-	if out, err := cmd.CombinedOutput(); err != nil {
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		return fmt.Errorf("error: %v, output: %s", err, string(out))
 	}
+	log.Debug("cmd out", zap.String("out", string(out)))
 	return nil
 }
 


### PR DESCRIPTION
Two db cluster can be on the same timeline but forked at different
points in previous timelines. pg_rewind doesn't consider this case and
thinks that they are in sync and a rewind isn't needed.

Handle this case checking if, after pg_rewind, the db are not in sync and
launch a full resync.