### PR TITLE
cluster: don't save keeper/db first error time

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -375,8 +375,7 @@ type DBSpec struct {
 }
 
 type DBStatus struct {
-	ErrorStartTime time.Time `json:"errorStartTime,omitempty"`
-	Healthy        bool      `json:"healthy,omitempty"`
+	Healthy bool `json:"healthy,omitempty"`
 
 	CurrentGeneration int64 `json:"currentGeneration,omitempty"`
 
@@ -485,24 +484,4 @@ func (cd *ClusterData) FindDB(keeper *Keeper) *DB {
 		}
 	}
 	return nil
-}
-
-func (k *Keeper) SetError() {
-	if k.Status.ErrorStartTime.IsZero() {
-		k.Status.ErrorStartTime = time.Now()
-	}
-}
-
-func (k *Keeper) CleanError() {
-	k.Status.ErrorStartTime = time.Time{}
-}
-
-func (d *DB) SetError() {
-	if d.Status.ErrorStartTime.IsZero() {
-		d.Status.ErrorStartTime = time.Now()
-	}
-}
-
-func (d *DB) CleanError() {
-	d.Status.ErrorStartTime = time.Time{}
 }


### PR DESCRIPTION
Saving the keeper and db first error time in the cluster data make this
subscetible to clock skews between sentinels if a new one becomes the
master.

This patch moves the first error time to a sentinel in memory value.
When a new sentinel becomes the master (or the current one is restarted)
the timers are empty so the failure detection time restarts. This isn't
a usually a big problem (just more time to declare a keeper non
healthy).