### PR TITLE
*: Use monotonic timer

### DIFF
--- a/pkg/timer/timer.go
+++ b/pkg/timer/timer.go
@@ -1,0 +1,22 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timer
+
+import "time"
+
+// Since return the duration since the starting time
+func Since(start int64) time.Duration {
+	return time.Duration(Now() - start)
+}

--- a/pkg/timer/timer_fallback.go
+++ b/pkg/timer/timer_fallback.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package timer
+
+import (
+	"time"
+)
+
+func Now() int64 {
+	return time.Now().UnixNano()
+}

--- a/pkg/timer/timer_linux.go
+++ b/pkg/timer/timer_linux.go
@@ -1,0 +1,37 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package timer
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	// from /usr/include/linux/time.h
+	CLOCK_MONOTONIC = 1
+)
+
+// TODO(sgotti) for the moment just use a syscall so it'll work on all linux
+// architectures. It's slower than using a vdso but we don't have such performance
+// needs. Let's wait for a stdlib native monotonic clock.
+func Now() int64 {
+	var ts syscall.Timespec
+	syscall.Syscall(syscall.SYS_CLOCK_GETTIME, CLOCK_MONOTONIC, uintptr(unsafe.Pointer(&ts)), 0)
+	nsec := ts.Nano()
+	return nsec
+}


### PR DESCRIPTION
This patch adds monotonic timer support for linux. A monotonic timer is
definitely needed to avoid problems in the elapsed time calculation if
the clock jumps backward/forward due to external changes (by the user or
for any other reason).

We currently just use a clock_gettime syscall instead of the vdso since
we don't have so many calls and the perfomance gap is not noticeable and
the syscall will work on every linux arch.

The Now() method returns an int64 instead of a time.Time since it's not
a wall clock but a time since an unspecified starting point.

The timer pkg also adds a Since utility function to easily calculate
elapsed time.