### PR TITLE
sentinel: don't use registered changetime to get db convergence state.

### DIFF
--- a/cmd/sentinel/sentinel_test.go
+++ b/cmd/sentinel/sentinel_test.go
@@ -1228,7 +1228,12 @@ func TestUpdateCluster(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		s := &Sentinel{id: "id", UIDFn: testUIDFn, RandFn: testRandFn}
+		s := &Sentinel{id: "id", UIDFn: testUIDFn, RandFn: testRandFn, dbConvergenceInfos: make(map[string]*DBConvergenceInfo)}
+
+		// Populate db convergence timers, these are populated with a 0 timer to make them result like not converged.
+		for _, db := range tt.cd.DBs {
+			s.dbConvergenceInfos[db.UID] = &DBConvergenceInfo{Generation: 0, Timer: 0}
+		}
 
 		outcd, err := s.updateCluster(tt.cd)
 		t.Logf("test #%d", i)


### PR DESCRIPTION
Using the db ChangeTime saved in the cluster data to determine if a db
is converged makes the check subscetible to clock skews between
sentinels if a new one becomes the master and when the clock goes
backward/forward for whatever reason.

This patch moves the convergence interval calculation to a sentinel in
memory value.

When a new sentinel becomes the master (or the current one is restarted)
the timers are empty so the convergence detection time restarts. This
isn't a usually a big problem. It may have an impact on big convergence
times (for example during a restore) since there's a greater possibility
that another sentinel becomes the master/is restarted.