### PR TITLE
keeper: fix init pg parameters handling

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -691,10 +691,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	followersUIDs := db.Spec.Followers
 
 	prevPGParameters := pgm.GetParameters()
-	// create postgres parameteres
-	pgParameters := p.createPGParameters(db)
-	// update pgm postgres parameters
-	pgm.SetParameters(pgParameters)
+	var pgParameters common.Parameters
 
 	dbls := p.dbLocalState
 	if dbls.Initializing {
@@ -765,6 +762,12 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				log.Error("error", zap.Error(err))
 				return
 			}
+
+			// create postgres parameteres with empty InitPGParameters
+			pgParameters = p.createPGParameters(db)
+			// update pgm postgres parameters
+			pgm.SetParameters(pgParameters)
+
 			if started {
 				if err = pgm.Stop(true); err != nil {
 					log.Error("failed to stop pg instance", zap.Error(err))
@@ -789,7 +792,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				}
 				pgParameters, err = pgm.GetConfigFilePGParameters()
 				if err != nil {
-					log.Error("failed to rename previous postgresql.conf", zap.Error(err))
+					log.Error("failed to retrieve postgres parameters", zap.Error(err))
 					return
 				}
 				p.localStateMutex.Lock()
@@ -829,6 +832,12 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				log.Error("error", zap.Error(err))
 				return
 			}
+
+			// create postgres parameteres with empty InitPGParameters
+			pgParameters = p.createPGParameters(db)
+			// update pgm postgres parameters
+			pgm.SetParameters(pgParameters)
+
 			if started {
 				if err = pgm.Stop(true); err != nil {
 					log.Error("failed to stop pg instance", zap.Error(err))
@@ -855,7 +864,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				}
 				pgParameters, err = pgm.GetConfigFilePGParameters()
 				if err != nil {
-					log.Error("failed to rename previous postgresql.conf", zap.Error(err))
+					log.Error("failed to retrieve postgres parameters", zap.Error(err))
 					return
 				}
 				p.localStateMutex.Lock()
@@ -889,6 +898,12 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				log.Error("error", zap.Error(err))
 				return
 			}
+
+			// create postgres parameteres with empty InitPGParameters
+			pgParameters = p.createPGParameters(db)
+			// update pgm postgres parameters
+			pgm.SetParameters(pgParameters)
+
 			if started {
 				if err = pgm.Stop(true); err != nil {
 					log.Error("failed to stop pg instance", zap.Error(err))
@@ -903,7 +918,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				}
 				pgParameters, err = pgm.GetConfigFilePGParameters()
 				if err != nil {
-					log.Error("failed to rename previous postgresql.conf", zap.Error(err))
+					log.Error("failed to retrieve postgres parameters", zap.Error(err))
 					return
 				}
 				p.localStateMutex.Lock()
@@ -947,6 +962,9 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 		}
 	}
 
+	// create postgres parameteres
+	pgParameters = p.createPGParameters(db)
+	// update pgm postgres parameters
 	pgm.SetParameters(pgParameters)
 
 	var localRole common.Role

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -171,9 +171,6 @@ func (p *Manager) StartTmpMerged(args ...string) error {
 		return err
 	}
 
-	if err := p.WriteConf(); err != nil {
-		return fmt.Errorf("error writing conf file: %v", err)
-	}
 	if err := p.writePgHba(); err != nil {
 		return fmt.Errorf("error writing conf file: %v", err)
 	}


### PR DESCRIPTION
Don't write the postgresql.conf when starting with a temporary config
file.

Reset postgres manager init parameters when initializing.

Add/fix init tests to cover more cases.