### PR TITLE
 keeper: wait for updated keeper state at start.

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -236,11 +236,13 @@ func (s *Sentinel) updateKeepersStatus(cd *cluster.ClusterData, keepersInfo clus
 
 	// Mark keepers without a keeperInfo (cleaned up above from not updated
 	// ones) as in error
-	for keeperUID, _ := range cd.Keepers {
-		if _, ok := keepersInfo[keeperUID]; !ok {
+	for keeperUID, k := range cd.Keepers {
+		if ki, ok := keepersInfo[keeperUID]; !ok {
 			s.SetKeeperError(keeperUID)
 		} else {
 			s.CleanKeeperError(keeperUID)
+			// Update keeper status infos
+			k.Status.BootUUID = ki.BootUUID
 		}
 	}
 

--- a/common/common.go
+++ b/common/common.go
@@ -41,6 +41,10 @@ func UID() string {
 	return fmt.Sprintf("%x", u[:4])
 }
 
+func UUID() string {
+	return uuid.NewV4().String()
+}
+
 const (
 	stolonPrefix = "stolon_"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fbda1183a0947b03c695b5b5d2f3b8a6a697392c0f819d010eaf496dc09476db
-updated: 2016-11-10T16:59:56.823996052+01:00
+hash: 37ad54dfd451cec30e56572eb271771b8407095136ddc26c1e0db59999bdfcb1
+updated: 2016-11-23T11:24:52.287567975+01:00
 imports:
 - name: github.com/coreos/etcd
   version: bc9ddf260115d2680191c46977ae72b837785472
@@ -60,7 +60,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sgotti/gexpect
-  version: 81b69f472c22d5a42aefcf07b58015d0ef4da2e1
+  version: 0afc6c19f50a08b5f97f8c75f4b417f496d92377
 - name: github.com/sorintlab/pollon
   version: 279eb94a1432a0656f6da72d36f133dc68c2e064
 - name: github.com/spf13/cobra

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
 - package: github.com/satori/go.uuid
   version: v1.1.0
 - package: github.com/sgotti/gexpect
-  version: 81b69f472c22d5a42aefcf07b58015d0ef4da2e1
+  version: 0afc6c19f50a08b5f97f8c75f4b417f496d92377
 - package: github.com/sorintlab/pollon
   version: 279eb94a1432a0656f6da72d36f133dc68c2e064
 - package: github.com/spf13/cobra

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -307,6 +307,8 @@ type KeeperSpec struct{}
 
 type KeeperStatus struct {
 	Healthy bool `json:"healthy,omitempty"`
+
+	BootUUID string `json:"bootUUID,omitempty"`
 }
 
 type Keeper struct {
@@ -327,7 +329,8 @@ func NewKeeperFromKeeperInfo(ki *KeeperInfo) *Keeper {
 		ChangeTime: time.Time{},
 		Spec:       &KeeperSpec{},
 		Status: KeeperStatus{
-			Healthy: true,
+			Healthy:  true,
+			BootUUID: ki.BootUUID,
 		},
 	}
 }

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -45,6 +45,7 @@ type KeeperInfo struct {
 
 	UID        string `json:"uid,omitempty"`
 	ClusterUID string `json:"clusterUID,omitempty"`
+	BootUUID   string `json:"bootUUID,omitempty"`
 
 	PostgresState *PostgresState `json:"postgresState,omitempty"`
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -161,6 +161,7 @@ func NewTestKeeperWithID(t *testing.T, dir, id, clusterName, pgSUUsername, pgSUP
 
 	args = append(args, fmt.Sprintf("--id=%s", id))
 	args = append(args, fmt.Sprintf("--cluster-name=%s", clusterName))
+	args = append(args, fmt.Sprintf("--pg-listen-address=%s", pgListenAddress))
 	args = append(args, fmt.Sprintf("--pg-port=%s", pgPort))
 	args = append(args, fmt.Sprintf("--data-dir=%s", dataDir))
 	args = append(args, fmt.Sprintf("--store-backend=%s", storeBackend))


### PR DESCRIPTION
The keeper at start will generate a bootUUID and, before doing any
operation, will check that the generated bootUID matches the one
registered in the cluster data or will stop/keep stopped the database
instance.