### PR TITLE
semaphore: test with postgresql 9.5 and 9.6

### DIFF
--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -23,12 +23,12 @@ curl -L https://releases.hashicorp.com/consul/0.6.3/consul_0.6.3_linux_amd64.zip
 unzip consul_0.6.3_linux_amd64.zip
 popd
 
-# Install postgreSQL 9.5
+# Install postgreSQL 9.5 and 9.6
 # TODO(sgotti) remove this when semaphoreci images will have this already installed
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
-sudo apt-get -y install postgresql-9.5
+sudo apt-get -y install postgresql-9.5 postgresql-9.6
 
 # Precompile stdlib with cgo disable to speedup builds
 sudo -E CGO_ENABLED=0 go install -a -installsuffix cgo std
@@ -39,10 +39,10 @@ export CONSUL_BIN="${PWD}/consul/consul"
 
 OLDPATH=$PATH
 
-# Test with postgresql 9.4
-echo "===== Testing with postgreSQL 9.4 ====="
-export PATH=/usr/lib/postgresql/9.4/bin/:$OLDPATH ; INTEGRATION=1 ./test
-
 # Test with postgresql 9.5
 echo "===== Testing with postgreSQL 9.5 ====="
 export PATH=/usr/lib/postgresql/9.5/bin/:$OLDPATH ; INTEGRATION=1 ./test
+
+# Test with postgresql 9.6
+echo "===== Testing with postgreSQL 9.6 ====="
+export PATH=/usr/lib/postgresql/9.6/bin/:$OLDPATH ; INTEGRATION=1 ./test


### PR DESCRIPTION
Drop tests with 9.4 to avoid too long test times.