### PR TITLE
sentinel: use negative db convergence timer value in tests

### DIFF
--- a/cmd/sentinel/sentinel_test.go
+++ b/cmd/sentinel/sentinel_test.go
@@ -1230,9 +1230,9 @@ func TestUpdateCluster(t *testing.T) {
 	for i, tt := range tests {
 		s := &Sentinel{id: "id", UIDFn: testUIDFn, RandFn: testRandFn, dbConvergenceInfos: make(map[string]*DBConvergenceInfo)}
 
-		// Populate db convergence timers, these are populated with a 0 timer to make them result like not converged.
+		// Populate db convergence timers, these are populated with a negative timer to make them result like not converged.
 		for _, db := range tt.cd.DBs {
-			s.dbConvergenceInfos[db.UID] = &DBConvergenceInfo{Generation: 0, Timer: 0}
+			s.dbConvergenceInfos[db.UID] = &DBConvergenceInfo{Generation: 0, Timer: int64(-1000 * time.Hour)}
 		}
 
 		outcd, err := s.updateCluster(tt.cd)


### PR DESCRIPTION
Since the semaphore ci linux machine has a monotonic clock starting from
zero when booted, the sentinel tests were sometimes failing not
considering the db as not converged.

Fix this by setting the db convergence timer to a quite big negative
value.