### PR TITLE
doc: update for new changes

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -153,9 +153,11 @@ kubectl delete pods stolon-keeper-rc-qpqp9
 
 You can take a look at the leader sentinel log and will see that after some seconds it'll declare the master keeper as not healthy and elect the other one as the new master:
 ```
-2015-10-16 19:20:53.766228 [sentinel.go:506] I | sentinel: master is failed
-2015-10-16 19:20:53.766243 [sentinel.go:518] I | sentinel: trying to find a standby to replace failed master
-2015-10-16 19:20:53.767604 [sentinel.go:524] I | sentinel: electing new master: "1749142f"
+no keeper info available db=cb96f42d keeper=d8de7dc1
+no keeper info available db=cb96f42d keeper=d8de7dc1
+master db is failed db=cb96f42d keeper=d8de7dc1
+trying to find a standby to replace failed master
+electing db as the new master db=087ce88a keeper=1749142f
 ```
 
 Now, inside the previous `psql` session you can redo the last select. The first time `psql` will report that the connection was closed and then it successfully reconnected:


### PR DESCRIPTION
The logging output has changed in #187. Fix command output reported in
the doc to the new format.

Remove a `--port` option leftover (doesn't exist anymore from #195).