### PR TITLE
*: enable tls support for store

### DIFF
--- a/cmd/stolonctl/init.go
+++ b/cmd/stolonctl/init.go
@@ -18,11 +18,9 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/sorintlab/stolon/common"
 	"github.com/sorintlab/stolon/pkg/cluster"
-	"github.com/sorintlab/stolon/pkg/store"
 	"github.com/spf13/cobra"
 )
 
@@ -72,12 +70,10 @@ func initCluster(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	e, err := NewStore()
 	if err != nil {
 		die("cannot create store: %v", err)
 	}
-	e := store.NewStoreManager(kvstore, storePath)
 
 	cd, _, err := e.GetClusterData()
 	if err != nil {

--- a/cmd/stolonctl/spec.go
+++ b/cmd/stolonctl/spec.go
@@ -16,10 +16,6 @@ package main
 
 import (
 	"encoding/json"
-	"path/filepath"
-
-	"github.com/sorintlab/stolon/common"
-	"github.com/sorintlab/stolon/pkg/store"
 
 	"github.com/spf13/cobra"
 )
@@ -35,13 +31,10 @@ func init() {
 }
 
 func spec(cmd *cobra.Command, args []string) {
-	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
-
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	e, err := NewStore()
 	if err != nil {
 		die("cannot create store: %v", err)
 	}
-	e := store.NewStoreManager(kvstore, storePath)
 
 	cd, _, err := getClusterData(e)
 	if err != nil {

--- a/cmd/stolonctl/status.go
+++ b/cmd/stolonctl/status.go
@@ -17,13 +17,11 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"text/tabwriter"
 
 	"github.com/sorintlab/stolon/common"
 	"github.com/sorintlab/stolon/pkg/cluster"
-	"github.com/sorintlab/stolon/pkg/store"
 
 	"github.com/spf13/cobra"
 )
@@ -84,13 +82,11 @@ func status(cmd *cobra.Command, args []string) {
 	if cfg.clusterName == "" {
 		die("cluster name required")
 	}
-	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
 
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	e, err := NewStore()
 	if err != nil {
 		die("cannot create store: %v", err)
 	}
-	e := store.NewStoreManager(kvstore, storePath)
 
 	sentinelsInfo, err := e.GetSentinelsInfo()
 	if err != nil {

--- a/cmd/stolonctl/update.go
+++ b/cmd/stolonctl/update.go
@@ -19,11 +19,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
-	"github.com/sorintlab/stolon/common"
 	"github.com/sorintlab/stolon/pkg/cluster"
-	"github.com/sorintlab/stolon/pkg/store"
 
 	libkvstore "github.com/docker/libkv/store"
 	"github.com/spf13/cobra"
@@ -96,12 +93,10 @@ func update(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	storePath := filepath.Join(common.StoreBasePath, cfg.clusterName)
-	kvstore, err := store.NewStore(store.Backend(cfg.storeBackend), cfg.storeEndpoints)
+	e, err := NewStore()
 	if err != nil {
 		die("cannot create store: %v", err)
 	}
-	e := store.NewStoreManager(kvstore, storePath)
 
 	retry := 0
 	for retry < maxRetries {

--- a/common/tls.go
+++ b/common/tls.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+)
+
+func NewTLSConfig(certFile, keyFile, caFile string, insecureSkipVerify bool) (*tls.Config, error) {
+	tlsConfig := tls.Config{}
+
+	// Populate root CA certs
+	if caFile != "" {
+		pemBytes, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			return nil, err
+		}
+		roots := x509.NewCertPool()
+
+		for {
+			var block *pem.Block
+			block, pemBytes = pem.Decode(pemBytes)
+			if block == nil {
+				break
+			}
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			roots.AddCert(cert)
+		}
+
+		tlsConfig.RootCAs = roots
+	}
+
+	// Populate keypair
+	// both must be defined
+	if certFile != "" && keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	tlsConfig.InsecureSkipVerify = insecureSkipVerify
+
+	return &tlsConfig, nil
+}

--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -25,7 +25,7 @@ spec:
           - name: STKEEPER_STORE_BACKEND
             value: "etcd" # Or consul
           - name: STKEEPER_STORE_ENDPOINTS
-            value: "10.245.1.1:2379"
+            value: "http://10.245.1.1:2379"
             # Enable debugging
           - name: STKEEPER_PG_REPL_USERNAME
             value: "repluser"

--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -25,7 +25,7 @@ spec:
           - name: STPROXY_STORE_BACKEND
             value: "etcd" # Or consul
           - name: STPROXY_STORE_ENDPOINTS
-            value: "10.245.1.1:2379"
+            value: "http://10.245.1.1:2379"
             # Enable debugging
           - name: STPROXY_DEBUG
             value: "true"

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -24,7 +24,7 @@ spec:
           - name: STSENTINEL_STORE_BACKEND
             value: "etcd" # Or consul
           - name: STSENTINEL_STORE_ENDPOINTS
-            value: "10.245.1.1:2379"
+            value: "http://10.245.1.1:2379"
             # Enable debugging
           - name: STSENTINEL_DEBUG
             value: "true"

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -545,7 +545,11 @@ func NewTestEtcd(t *testing.T, dir string, a ...string) (*TestStore, error) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", listenAddress, port)
 
-	kvstore, err := store.NewStore(store.ETCD, storeEndpoints)
+	storeConfig := store.Config{
+		Backend:   store.ETCD,
+		Endpoints: storeEndpoints,
+	}
+	kvstore, err := store.NewStore(storeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}
@@ -627,7 +631,11 @@ func NewTestConsul(t *testing.T, dir string, a ...string) (*TestStore, error) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", listenAddress, portHTTP)
 
-	kvstore, err := store.NewStore(store.CONSUL, storeEndpoints)
+	storeConfig := store.Config{
+		Backend:   store.CONSUL,
+		Endpoints: storeEndpoints,
+	}
+	kvstore, err := store.NewStore(storeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %v", err)
 	}


### PR DESCRIPTION
To enable tls the endpoints should be provided with an https scheme.

Add an option to define the ca file to verify the server certificate.
Add options to set the client cert and key pairs (for client
authentication with etcd)
Add an option to skip server tls cert verification.