### PR TITLE
tests: various cleanups

### DIFF
--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -55,11 +55,7 @@ func TestServerParameters(t *testing.T) {
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
-	if err != nil {
-		t.Fatalf("cannot create store: %v", err)
-	}
-	e := store.NewStoreManager(kvstore, storePath)
+	sm := store.NewStoreManager(tstore.store, storePath)
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:           cluster.ClusterInitModeNew,
@@ -86,7 +82,7 @@ func TestServerParameters(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
-	if err := WaitClusterPhase(e, cluster.ClusterPhaseNormal, 60*time.Second); err != nil {
+	if err := WaitClusterPhase(sm, cluster.ClusterPhaseNormal, 60*time.Second); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if err := tk.WaitDBUp(60 * time.Second); err != nil {

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -56,12 +56,7 @@ func TestPITR(t *testing.T) {
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
-	if err != nil {
-		t.Fatalf("cannot create store: %v", err)
-	}
-
-	e := store.NewStoreManager(kvstore, storePath)
+	sm := store.NewStoreManager(tstore.store, storePath)
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:           cluster.ClusterInitModeNew,
@@ -96,7 +91,7 @@ func TestPITR(t *testing.T) {
 	}
 
 	// Wait for clusterView containing a master
-	_, err = WaitClusterDataWithMaster(e, 30*time.Second)
+	_, err = WaitClusterDataWithMaster(sm, 30*time.Second)
 	if err != nil {
 		t.Fatal("expected a master in cluster view")
 	}
@@ -170,10 +165,10 @@ func TestPITR(t *testing.T) {
 	}
 	defer ts.Stop()
 
-	if err := WaitClusterPhase(e, cluster.ClusterPhaseNormal, 60*time.Second); err != nil {
+	if err := WaitClusterPhase(sm, cluster.ClusterPhaseNormal, 60*time.Second); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	_, err = WaitClusterDataWithMaster(e, 30*time.Second)
+	_, err = WaitClusterDataWithMaster(sm, 30*time.Second)
 	if err != nil {
 		t.Fatal("expected a master in cluster view")
 	}

--- a/tests/integration/proxy_test.go
+++ b/tests/integration/proxy_test.go
@@ -77,12 +77,7 @@ func TestProxyListening(t *testing.T) {
 
 	storePath := filepath.Join(common.StoreBasePath, clusterName)
 
-	kvstore, err := store.NewStore(tstore.storeBackend, storeEndpoints)
-	if err != nil {
-		t.Fatalf("cannot create store: %v", err)
-	}
-
-	e := store.NewStoreManager(kvstore, storePath)
+	sm := store.NewStoreManager(tstore.store, storePath)
 
 	cd := &cluster.ClusterData{
 		FormatVersion: cluster.CurrentCDFormatVersion,
@@ -130,7 +125,7 @@ func TestProxyListening(t *testing.T) {
 			},
 		},
 	}
-	pair, err := e.AtomicPutClusterData(cd, nil)
+	pair, err := sm.AtomicPutClusterData(cd, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -174,7 +169,7 @@ func TestProxyListening(t *testing.T) {
 	t.Logf("test proxyConf removed. Should continue listening")
 	// remove proxyConf
 	cd.Proxy.Spec.MasterDBUID = ""
-	pair, err = e.AtomicPutClusterData(cd, pair)
+	pair, err = sm.AtomicPutClusterData(cd, pair)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -187,7 +182,7 @@ func TestProxyListening(t *testing.T) {
 	t.Logf("test proxyConf restored. Should continue listening")
 	// Set proxyConf again
 	cd.Proxy.Spec.MasterDBUID = "01"
-	pair, err = e.AtomicPutClusterData(cd, pair)
+	pair, err = sm.AtomicPutClusterData(cd, pair)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -199,7 +194,7 @@ func TestProxyListening(t *testing.T) {
 
 	t.Logf("test clusterView removed. Should continue listening")
 	// remove whole clusterview
-	_, err = e.AtomicPutClusterData(nil, pair)
+	_, err = sm.AtomicPutClusterData(nil, pair)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -552,7 +552,7 @@ func NewTestEtcd(t *testing.T, dir string, a ...string) (*TestStore, error) {
 	if bin == "" {
 		return nil, fmt.Errorf("missing ETCD_BIN env")
 	}
-	te := &TestStore{
+	tstore := &TestStore{
 		t: t,
 		Process: Process{
 			t:    t,
@@ -566,7 +566,7 @@ func NewTestEtcd(t *testing.T, dir string, a ...string) (*TestStore, error) {
 		store:         kvstore,
 		storeBackend:  store.ETCD,
 	}
-	return te, nil
+	return tstore, nil
 }
 
 func NewTestConsul(t *testing.T, dir string, a ...string) (*TestStore, error) {


### PR DESCRIPTION
* setupServer doesn't wait for db being up but just starts all the
keepers.

* getRoles renamed to waitMasterStandbysReady. It now reads the cluster
data waiting for a master being ready.

* Renamed multiple test store related variables and removed unuseful
kvstore creation since it's already provided by the teststore.