### PR TITLE
store: remove prev value before AtomicPut

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -109,7 +109,16 @@ func (e *StoreManager) AtomicPutClusterData(cd *cluster.ClusterData, previous *k
 		return nil, err
 	}
 	path := filepath.Join(e.clusterPath, clusterDataFile)
-	_, pair, err := e.store.AtomicPut(path, cdj, previous, nil)
+	// Skip prev Value since LastIndex is enough for a CAS and it gives
+	// problem with etcd v2 api with big prev values.
+	var prev *kvstore.KVPair
+	if previous != nil {
+		prev = &kvstore.KVPair{
+			Key:       previous.Key,
+			LastIndex: previous.LastIndex,
+		}
+	}
+	_, pair, err := e.store.AtomicPut(path, cdj, prev, nil)
 	return pair, err
 }
 


### PR DESCRIPTION
libkv etcd implementation populates both prevIndex and prevValue to the
v2 api. This is causing problems with big values (since it puts the
prevValue in the PUT url).

This patch removes the KVPair Value before invoking the AtomicPut.