### PR TITLE
stolon: control db resync from the sentinel

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -103,8 +103,10 @@ const (
 	DBInitModeExisting DBInitMode = "existing"
 	// Initialize a db starting from a freshly initialized database cluster
 	DBInitModeNew DBInitMode = "new"
-	// Initialize a db doing a point in time recovery.
+	// Initialize a db doing a point in time recovery
 	DBInitModePITR DBInitMode = "pitr"
+	// Initialize a db doing a resync to a target database cluster
+	DBInitModeResync DBInitMode = "resync"
 )
 
 type PITRConfig struct {


### PR DESCRIPTION
This patch move the control of db resync from the keeper to the
sentinel.

Now a resync is allowed only during db initialization, so if the
sentinel choose that a db needs a resync it should remove the current db
from the cluster data and define a new db with initMode == resync. The
keeper will resync only when it sees a new db assigned to it and choose
if it makes sense to use pg_rewind or do a full resync.

For this reason the "bad" db detection (branched or different systemID
(this should happen only if a user changes a standby db data out of the
stolon control) is done by the sentinel.

This has other advantages:
* since it's the sentinel detecting bad dbs it can better control
standby removal from the clusterdata and from future proxing.
* the resync db initMode can also be used for initializing a standby
cluster.