### PR TITLE
Handle SIGTERM as well as SIGINT for shutdown.

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sorintlab/stolon/common"
@@ -1421,7 +1422,7 @@ func keeper(cmd *cobra.Command, args []string) {
 	stop := make(chan bool, 0)
 	end := make(chan error, 0)
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt, os.Kill)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go sigHandler(sigs, stop)
 
 	p, err := NewPostgresKeeper(&cfg, stop, end)

--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sorintlab/stolon/common"
@@ -1410,7 +1411,7 @@ func sentinel(cmd *cobra.Command, args []string) {
 	stop := make(chan bool, 0)
 	end := make(chan bool, 0)
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt, os.Kill)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go sigHandler(sigs, stop)
 
 	s, err := NewSentinel(uid, &cfg, stop, end)


### PR DESCRIPTION
The current keeper code is handling only SIGINT for shutdown. If the keeper receives a SIGTERM it shuts down uncleanly. If running inside a Docker container, this means the Postgres process is killed uncleanly as well, which is bad.

This is important because Docker's `docker stop` and Kubernetes' `kubectl delete pod` stop the container by sending SIGTERM. 

This PR: 
- Adds SIGTERM to the handler
- Removes SIGKILL, since it can't be catched.
- Changes SIGINT to use syscall as well, for consistency.