### PR TITLE
Unnecessary escaping newline

### DIFF
--- a/examples/docker/Dockerfile-Keeper
+++ b/examples/docker/Dockerfile-Keeper
@@ -3,7 +3,7 @@ FROM postgres:9.6.1
 ENV STKEEPER_CLUSTER_NAME=stolon-cluster \
     STKEEPER_STORE_BACKEND=etcd \
     STKEEPER_STORE_ENDPOINTS=http://localhost:2379 \
-    STKEEPER_DATA_DIR=/data/postgres \
+    STKEEPER_DATA_DIR=/data/postgres
 
 RUN mkdir -p ${STKEEPER_DATA_DIR} && \
     chmod 700 ${STKEEPER_DATA_DIR} && \


### PR DESCRIPTION
Causes a error: Error response from daemon: Syntax error - can't find = in "RUN". Must be of the form: name=value