### PR TITLE
k8s examples: missing for for rc/stolon-keeper1.yaml

### DIFF
--- a/examples/kubernetes/rc/stolon-keeper1.yaml
+++ b/examples/kubernetes/rc/stolon-keeper1.yaml
@@ -25,8 +25,9 @@ spec:
           - |
             export POD_IP=$(hostname -i)
             export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
-            chown stolon:stolon $PGDATA
-            exec gosu stolon stolon-keeper --data-dir $PGDATA
+            export STOLON_DATA=/stolon-data
+            chown stolon:stolon $STOLON_DATA
+            exec gosu stolon stolon-keeper --data-dir $STOLON_DATA
         env:
           - name: STKEEPER_UID
             value: "keeper1"


### PR DESCRIPTION
In 7b2525de287a169c68fd21403236a189df338ce9 we forgot to also fix
rc/stolon-keeper1.yaml