### PR TITLE
*: support postgresql 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Anyway it's quite easy to reset a cluster from scratch keeping the current maste
 
 ## Requirements
 
-* PostgreSQL >= 9.4
+* PostgreSQL 10 or 9 (9.4, 9.5, 9.6)
 * etcd >= 2.0 or consul >=0.6
 
 

--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -454,16 +454,21 @@ func (p *PostgresKeeper) updatePGState(pctx context.Context) {
 // parseSynchronousStandbyNames extracts the standby names from the
 // "synchronous_standby_names" postgres parameter.
 //
-// Since postgres 9.6
-//   https://www.postgresql.org/docs/9.6/static/runtime-config-replication.html
+// Since postgres 9.6 (https://www.postgresql.org/docs/9.6/static/runtime-config-replication.html)
 // `synchronous_standby_names` can be in one of two formats:
 //   num_sync ( standby_name [, ...] )
 //   standby_name [, ...]
 // two examples for this:
 //   2 (node1,node2)
 //   node1,node2
-//
-// Only postgres >= 9.6 supports the second format.
+// TODO(sgotti) since postgres 10 (https://www.postgresql.org/docs/10/static/runtime-config-replication.html)
+// `synchronous_standby_names` can be in one of three formats:
+//   [FIRST] num_sync ( standby_name [, ...] )
+//   ANY num_sync ( standby_name [, ...] )
+//   standby_name [, ...]
+// since we are writing ourself the synchronous_standby_names we don't handle this case.
+// If needed, to better handle all the cases with also a better validation of
+// standby names we could use something like the parser used by postgres
 func parseSynchronousStandbyNames(s string) ([]string, error) {
 	var spacesSplit []string = strings.Split(s, " ")
 	var entries []string

--- a/pkg/postgresql/utils_test.go
+++ b/pkg/postgresql/utils_test.go
@@ -127,3 +127,81 @@ func TestExpand(t *testing.T) {
 		}
 	}
 }
+
+func TestParseBinaryVersion(t *testing.T) {
+	tests := []struct {
+		in  string
+		maj int
+		min int
+		err error
+	}{
+		{
+			in:  "postgres (PostgreSQL) 9.5.7",
+			maj: 9,
+			min: 5,
+		},
+		{
+			in:  "postgres (PostgreSQL) 10beta1",
+			maj: 10,
+			min: 0,
+		},
+		{
+			in:  "postgres (PostgreSQL) 10.1.2",
+			maj: 10,
+			min: 1,
+		},
+	}
+
+	for i, tt := range tests {
+		maj, min, err := ParseBinaryVersion(tt.in)
+		t.Logf("test #%d", i)
+		if tt.err != nil {
+			if err == nil {
+				t.Fatalf("got no error, wanted error: %v", tt.err)
+			} else if tt.err.Error() != err.Error() {
+				t.Fatalf("got error: %v, wanted error: %v", err, tt.err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if maj != tt.maj || min != tt.min {
+				t.Fatalf("#%d: wrong maj.min version: got: %d.%d, want: %d.%d", i, maj, min, tt.maj, tt.min)
+			}
+		}
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		in  string
+		maj int
+		min int
+		err error
+	}{
+		{
+			in:  "9.5.7",
+			maj: 9,
+			min: 5,
+		},
+	}
+
+	for i, tt := range tests {
+		maj, min, err := ParseVersion(tt.in)
+		t.Logf("test #%d", i)
+		if tt.err != nil {
+			if err == nil {
+				t.Fatalf("got no error, wanted error: %v", tt.err)
+			} else if tt.err.Error() != err.Error() {
+				t.Fatalf("got error: %v, wanted error: %v", err, tt.err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if maj != tt.maj || min != tt.min {
+				t.Fatalf("#%d: wrong maj.min versio : got: %d.%d, want: %d.%d", i, maj, min, tt.maj, tt.min)
+			}
+		}
+	}
+}

--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -25,10 +25,10 @@ popd
 
 # Install postgreSQL 9.5 and 9.6
 # TODO(sgotti) remove this when semaphoreci images will have this already installed
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main 10" > /etc/apt/sources.list.d/pgdg.list'
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
-sudo apt-get -y install postgresql-9.5 postgresql-9.6
+sudo apt-get -y install postgresql-9.5 postgresql-9.6 postgresql-10
 
 # Precompile stdlib with cgo disable to speedup builds
 sudo -E CGO_ENABLED=0 go install -a -installsuffix cgo std
@@ -46,3 +46,7 @@ export PATH=/usr/lib/postgresql/9.5/bin/:$OLDPATH ; INTEGRATION=1 ./test
 # Test with postgresql 9.6
 echo "===== Testing with postgreSQL 9.6 ====="
 export PATH=/usr/lib/postgresql/9.6/bin/:$OLDPATH ; INTEGRATION=1 ./test
+
+# Test with postgresql 10
+echo "===== Testing with postgreSQL 10 ====="
+export PATH=/usr/lib/postgresql/10/bin/:$OLDPATH ; INTEGRATION=1 ./test

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -123,8 +123,18 @@ func TestPITR(t *testing.T) {
 	}
 
 	// Switch wal so they will be archived
-	if _, err := tk.db.Exec("select pg_switch_xlog()"); err != nil {
+	maj, _, err := tk.PGDataVersion()
+	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
+	}
+	if maj < 10 {
+		if _, err := tk.db.Exec("select pg_switch_xlog()"); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	} else {
+		if _, err := tk.db.Exec("select pg_switch_wal()"); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
 	}
 
 	ts.Stop()

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -228,6 +228,22 @@ func NewTestKeeper(t *testing.T, dir, clusterName, pgSUUsername, pgSUPassword, p
 	return NewTestKeeperWithID(t, dir, uid, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, storeBackend, storeEndpoints, a...)
 }
 
+func (tk *TestKeeper) PGDataVersion() (int, int, error) {
+	fh, err := os.Open(filepath.Join(tk.dataDir, "postgres", "PG_VERSION"))
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read PG_VERSION: %v", err)
+	}
+	defer fh.Close()
+
+	scanner := bufio.NewScanner(fh)
+	scanner.Split(bufio.ScanLines)
+
+	scanner.Scan()
+
+	version := scanner.Text()
+	return pg.ParseVersion(version)
+}
+
 func (tk *TestKeeper) Exec(query string, args ...interface{}) (sql.Result, error) {
 	res, err := tk.db.Exec(query, args...)
 	if err != nil {


### PR DESCRIPTION
Add support for postgresql 10 (at least for current beta1).

The changes are minimal:

* Add detection for current pgdata version (also add detection for
binaries version (currently not used))
* Handle different pgdata directories between postgres 9 and 10.
* Use pg_switch_xlog or pg_switch_wal if on 9 or 10 (used only in
integration tests)

Test also postgres10 on semaphore so we'll notice if some breaking
changes are added during postgres10 development.