### PR TITLE
tests: speedup semaphore tests

### DIFF
--- a/cmd/sentinel/sentinel.go
+++ b/cmd/sentinel/sentinel.go
@@ -374,7 +374,7 @@ func (s *Sentinel) isLagBelowMax(cd *cluster.ClusterData, curMasterDB, db *clust
 	if !*cd.Cluster.DefSpec().SynchronousReplication {
 		log.Debug(fmt.Sprintf("curMasterDB.Status.XLogPos: %d, db.Status.XLogPos: %d, lag: %d", curMasterDB.Status.XLogPos, db.Status.XLogPos, int64(curMasterDB.Status.XLogPos-db.Status.XLogPos)))
 		if int64(curMasterDB.Status.XLogPos-db.Status.XLogPos) > int64(*cd.Cluster.DefSpec().MaxStandbyLag) {
-			log.Debug("ignoring keeper since its behind that maximum xlog position", zap.String("db", db.UID), zap.Uint64("dbXLogPos", db.Status.XLogPos), zap.Uint64("masterXLogPos", curMasterDB.Status.XLogPos))
+			log.Info("ignoring keeper since its behind that maximum xlog position", zap.String("db", db.UID), zap.Uint64("dbXLogPos", db.Status.XLogPos), zap.Uint64("masterXLogPos", curMasterDB.Status.XLogPos))
 			return false
 		}
 	}

--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -39,14 +39,23 @@ export CONSUL_BIN="${PWD}/consul/consul"
 
 OLDPATH=$PATH
 
+# Increase sysv ipc semaphores to accomode a big number of parallel postgres instances
+sudo /bin/sh -c 'echo "32000 1024000000 500 32000" > /proc/sys/kernel/sem'
+
+# Free up some disk space
+rm -rf ~/.rbenv
+
+export INTEGRATION=1
+export PARALLEL=20
+
 # Test with postgresql 9.5
 echo "===== Testing with postgreSQL 9.5 ====="
-export PATH=/usr/lib/postgresql/9.5/bin/:$OLDPATH ; INTEGRATION=1 ./test
+export PATH=/usr/lib/postgresql/9.5/bin/:$OLDPATH ; ./test
 
 # Test with postgresql 9.6
 echo "===== Testing with postgreSQL 9.6 ====="
-export PATH=/usr/lib/postgresql/9.6/bin/:$OLDPATH ; INTEGRATION=1 ./test
+export PATH=/usr/lib/postgresql/9.6/bin/:$OLDPATH ; ./test
 
 # Test with postgresql 10
 echo "===== Testing with postgreSQL 10 ====="
-export PATH=/usr/lib/postgresql/10/bin/:$OLDPATH ; INTEGRATION=1 ./test
+export PATH=/usr/lib/postgresql/10/bin/:$OLDPATH ; ./test


### PR DESCRIPTION
Increase tests parallelization to 20.

Free up some disk space to have enough space for parallel test dirs.

Increase SysV ipc semaphores to handle a big number of parallel
postgres instances.