### PR TITLE
tests: force postgres logging to stderr

### DIFF
--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -130,7 +130,7 @@ func setupServers(t *testing.T, clusterName, dir string, numKeepers, numSentinel
 			MaxStandbyLag:          cluster.Uint32P(50 * 1024), // limit lag to 50kiB
 			SynchronousReplication: cluster.BoolP(syncRepl),
 			UsePgrewind:            cluster.BoolP(usePgrewind),
-			PGParameters:           make(cluster.PGParameters),
+			PGParameters:           defaultPGParameters,
 		}
 	} else {
 		// if primaryKeeper is provided then we should create a standby cluster and do a
@@ -151,7 +151,7 @@ func setupServers(t *testing.T, clusterName, dir string, numKeepers, numSentinel
 			ConvergenceTimeout:     &cluster.Duration{Duration: 30 * time.Second},
 			MaxStandbyLag:          cluster.Uint32P(50 * 1024), // limit lag to 50kiB
 			SynchronousReplication: cluster.BoolP(syncRepl),
-			PGParameters:           make(cluster.PGParameters),
+			PGParameters:           defaultPGParameters,
 			PITRConfig: &cluster.PITRConfig{
 				DataRestoreCommand: fmt.Sprintf("PGPASSFILE=%s pg_basebackup -D %%d -h %s -p %s -U %s", pgpass.Name(), primaryKeeper.pgListenAddress, primaryKeeper.pgPort, primaryKeeper.pgReplUsername),
 			},
@@ -1142,7 +1142,7 @@ func TestFailedStandby(t *testing.T) {
 		FailInterval:         &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout:   &cluster.Duration{Duration: 30 * time.Second},
 		MaxStandbysPerSender: cluster.Uint16P(1),
-		PGParameters:         make(cluster.PGParameters),
+		PGParameters:         defaultPGParameters,
 	}
 
 	// Create 3 keepers
@@ -1233,7 +1233,7 @@ func TestLoweredMaxStandbysPerSender(t *testing.T) {
 		FailInterval:         &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout:   &cluster.Duration{Duration: 30 * time.Second},
 		MaxStandbysPerSender: cluster.Uint16P(2),
-		PGParameters:         make(cluster.PGParameters),
+		PGParameters:         defaultPGParameters,
 	}
 
 	// Create 3 keepers
@@ -1300,7 +1300,7 @@ func TestKeeperRemoval(t *testing.T) {
 		// very low DeadKeeperRemovalInterval to test this behavior
 		DeadKeeperRemovalInterval: &cluster.Duration{Duration: 10 * time.Second},
 		MaxStandbysPerSender:      cluster.Uint16P(1),
-		PGParameters:              make(cluster.PGParameters),
+		PGParameters:              defaultPGParameters,
 	}
 
 	// Create 2 keepers

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -50,6 +50,7 @@ func TestInit(t *testing.T) {
 		SleepInterval:      &cluster.Duration{Duration: 2 * time.Second},
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
+		PGParameters:       defaultPGParameters,
 	}
 	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {
@@ -112,6 +113,7 @@ func testInitNew(t *testing.T, merge bool) {
 		FailInterval:       &cluster.Duration{Duration: 10 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
 		MergePgParameters:  &merge,
+		PGParameters:       defaultPGParameters,
 	}
 	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {
@@ -187,9 +189,9 @@ func testInitExisting(t *testing.T, merge bool) {
 		SleepInterval:      &cluster.Duration{Duration: 2 * time.Second},
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
-		PGParameters: cluster.PGParameters{
+		PGParameters: pgParametersWithDefaults(cluster.PGParameters{
 			"archive_mode": "on",
-		},
+		}),
 	}
 	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {
@@ -234,6 +236,7 @@ func testInitExisting(t *testing.T, merge bool) {
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
 		MergePgParameters:  &merge,
+		PGParameters:       defaultPGParameters,
 		ExistingConfig: &cluster.ExistingConfig{
 			KeeperUID: tk.uid,
 		},
@@ -332,6 +335,7 @@ func TestInitUsers(t *testing.T) {
 		SleepInterval:      &cluster.Duration{Duration: 2 * time.Second},
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
+		PGParameters:       defaultPGParameters,
 	}
 	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {
@@ -423,6 +427,7 @@ func TestInitialClusterSpec(t *testing.T) {
 		FailInterval:           &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout:     &cluster.Duration{Duration: 30 * time.Second},
 		SynchronousReplication: cluster.BoolP(true),
+		PGParameters:           defaultPGParameters,
 	}
 	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -63,10 +63,10 @@ func TestPITR(t *testing.T) {
 		SleepInterval:      &cluster.Duration{Duration: 2 * time.Second},
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
-		PGParameters: cluster.PGParameters{
+		PGParameters: pgParametersWithDefaults(cluster.PGParameters{
 			"archive_mode":    "on",
 			"archive_command": fmt.Sprintf("cp %%p %s/%%f", archiveBackupDir),
-		},
+		}),
 	}
 	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {
@@ -160,9 +160,9 @@ func TestPITR(t *testing.T) {
 				RestoreCommand: fmt.Sprintf("cp %s/%%f %%p", archiveBackupDir),
 			},
 		},
-		PGParameters: cluster.PGParameters{
+		PGParameters: pgParametersWithDefaults(cluster.PGParameters{
 			"max_prepared_transactions": "100",
-		},
+		}),
 	}
 	initialClusterSpecFile, err = writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {

--- a/tests/integration/standby_test.go
+++ b/tests/integration/standby_test.go
@@ -105,7 +105,7 @@ func TestInitStandbyCluster(t *testing.T) {
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
 		MaxStandbyLag:      cluster.Uint32P(50 * 1024), // limit lag to 50kiB
-		PGParameters:       make(cluster.PGParameters),
+		PGParameters:       defaultPGParameters,
 		PITRConfig: &cluster.PITRConfig{
 			DataRestoreCommand: fmt.Sprintf("PGPASSFILE=%s pg_basebackup -D %%d -h %s -p %s -U %s", pgpass.Name(), ptk.pgListenAddress, ptk.pgPort, ptk.pgReplUsername),
 		},
@@ -232,7 +232,7 @@ func TestPromoteStandbyCluster(t *testing.T) {
 		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
 		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
 		MaxStandbyLag:      cluster.Uint32P(50 * 1024), // limit lag to 50kiB
-		PGParameters:       make(cluster.PGParameters),
+		PGParameters:       defaultPGParameters,
 		PITRConfig: &cluster.PITRConfig{
 			DataRestoreCommand: fmt.Sprintf("PGPASSFILE=%s pg_basebackup -D %%d -h %s -p %s -U %s", pgpass.Name(), ptk.pgListenAddress, ptk.pgPort, ptk.pgReplUsername),
 		},

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -51,8 +51,23 @@ const (
 	MaxPort = 16384
 )
 
+var (
+	defaultPGParameters = cluster.PGParameters{"log_destination": "stderr", "logging_collector": "false"}
+)
+
 var curPort = MinPort
 var portMutex = sync.Mutex{}
+
+func pgParametersWithDefaults(p cluster.PGParameters) cluster.PGParameters {
+	pd := cluster.PGParameters{}
+	for k, v := range defaultPGParameters {
+		pd[k] = v
+	}
+	for k, v := range p {
+		pd[k] = v
+	}
+	return pd
+}
 
 type Process struct {
 	t    *testing.T


### PR DESCRIPTION
some distribution have a template postgresql.conf used by initdb that
enables some custom logging (for example fedora enables the logging
collector and logging to a file).

For debugging purposes, we want to see the postgres instance logs in the
tests output.