### PR TITLE
keeper: check/wait for db ready

### DIFF
--- a/pkg/postgresql/utils.go
+++ b/pkg/postgresql/utils.go
@@ -75,7 +75,7 @@ func query(ctx context.Context, db *sql.DB, query string, args ...interface{}) (
 	}
 }
 
-func checkDBStatus(ctx context.Context, connParams ConnParams) error {
+func ping(ctx context.Context, connParams ConnParams) error {
 	db, err := sql.Open("postgres", connParams.ConnString())
 	if err != nil {
 		return err


### PR DESCRIPTION
running pg_ctl -w means it will wait for a timeout (default 60 seconds)
for the db accepting connection. But after the timeouts pg_ctl returns
an exit code of 0 and the keeper interprets this as the db being ready.

We should instead additonally check if the db is really ready or
error/wait based on the current operation:

* On PITR we should wait for a longer timeout (since restoring wals can
take a long time).
* After a resync with pg_rewind, if the db isn't ready, we assume that
it's probably waiting for some unavailable wals, so we force a full
resync.

In the meantime force the pg_ctl start timeout to 60 seconds (default)
to avoid having this overwritten by a parent PGCTLTIMEOUT environment
variable.