### PR TITLE
keeper: fix pg_rewind invocation

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -617,7 +617,7 @@ func (p *Manager) SyncFromFollowedPGRewind(followedConnParams ConnParams, passwo
 	log.Info("running pg_rewind")
 	name := filepath.Join(p.pgBinPath, "pg_rewind")
 	cmd := exec.Command(name, "--debug", "-D", p.dataDir, "--source-server="+followedConnString)
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSFILE=%s", pgpass.Name()))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSFILE=%s", pgpass.Name()))
 	log.Debug("execing cmd", zap.Object("cmd", cmd))
 
 	//Pipe command's std[err|out] to parent.
@@ -658,7 +658,7 @@ func (p *Manager) SyncFromFollowed(followedConnParams ConnParams) error {
 	log.Info("running pg_basebackup")
 	name := filepath.Join(p.pgBinPath, "pg_basebackup")
 	cmd := exec.Command(name, "-R", "-D", p.dataDir, "-d", followedConnString)
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSFILE=%s", pgpass.Name()))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSFILE=%s", pgpass.Name()))
 	log.Debug("execing cmd", zap.Object("cmd", cmd))
 
 	//Pipe command's std[err|out] to parent.


### PR DESCRIPTION
We were emptying the pg_rewind environment since setting cmd.Env != nil
will make os.Exec to use only cmd.Env and not the parent environment. This
caused pg_rewind to fail while trying to find the `initdb` command.

Fix this keeping the parent environment. Only PATH is probably needed but
for the moment just do what is already done when executing pg_ctl
(preserve all the parent environment variables).

In the meantime improve TestTimelineFork to wait a bit more in case of a
successfull pg_rewind but with unavailable wals and add some additional
checks.