### PR TITLE
Fix typo in initialization log line

### DIFF
--- a/cmd/stolonctl/init.go
+++ b/cmd/stolonctl/init.go
@@ -82,7 +82,7 @@ func initCluster(cmd *cobra.Command, args []string) {
 	if cd != nil {
 		stdout("WARNING: The current cluster data will be removed")
 	}
-	stdout("WARNING: The databases managed by the keepers will be overwrited depending on the provided cluster spec.")
+	stdout("WARNING: The databases managed by the keepers will be overwritten depending on the provided cluster spec.")
 
 	accepted := true
 	if !initOpts.forceYes {


### PR DESCRIPTION
In the `initCluster()` function there was a log line to `stdout` where we
warn the user that the database data will be overwritten. The word overwritten
was mis-typed as overwrited. This change fixes that.

Signed-off-by: Tim Heckman <t@heckman.io>