### PR TITLE
proxy: handle check timeouts and errors

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -44,7 +44,8 @@ const (
 )
 
 const (
-	DefaultProxyCheckInterval = 5 * time.Second
+	DefaultProxyCheckInterval   = 5 * time.Second
+	DefaultProxyTimeoutInterval = 15 * time.Second
 
 	DefaultSleepInterval                         = 5 * time.Second
 	DefaultRequestTimeout                        = 10 * time.Second

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -555,6 +555,13 @@ func (tp *TestProxy) WaitListening(timeout time.Duration) error {
 	return fmt.Errorf("timeout")
 }
 
+func (tp *TestProxy) CheckListening() bool {
+	_, err := net.Dial("tcp", net.JoinHostPort(tp.listenAddress, tp.port))
+	if err != nil {
+		return false
+	}
+	return true
+}
 func (tp *TestProxy) WaitNotListening(timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {


### PR DESCRIPTION
the Check function is critical, if it timeouts for whatever reason (i.e
blocked reading/writing to the store, resolving address etc...) the
proxy should drop connections and stop listening.

Since many functions non yet support a Context we use a timeout timer
to handle Check timing out (blocked) or returning an error.

As an additional gain, in this way we can also retry some times until
timeout when we have errors reading from the store while previously we
dropped connections at the first error.