### PR TITLE
sentinel: wait for proxies closing connections

### DIFF
--- a/cmd/sentinel/sentinel_test.go
+++ b/cmd/sentinel/sentinel_test.go
@@ -477,8 +477,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -559,8 +561,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -642,8 +646,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -717,7 +723,13 @@ func TestUpdateCluster(t *testing.T) {
 						},
 					},
 				},
-				Proxy: &cluster.Proxy{},
+				Proxy: &cluster.Proxy{
+					Generation: 2,
+					Spec: cluster.ProxySpec{
+						MasterDBUID:    "",
+						EnabledProxies: []string{},
+					},
+				},
 			},
 		},
 		// #6 From the previous test, new master (db2) converged. Old master setup to follow new master (db2).
@@ -792,7 +804,13 @@ func TestUpdateCluster(t *testing.T) {
 						},
 					},
 				},
-				Proxy: &cluster.Proxy{},
+				Proxy: &cluster.Proxy{
+					Generation: 1,
+					Spec: cluster.ProxySpec{
+						MasterDBUID:    "",
+						EnabledProxies: []string{},
+					},
+				},
 			},
 			outcd: &cluster.ClusterData{
 				Cluster: &cluster.Cluster{
@@ -870,8 +888,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 2,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db2",
+						MasterDBUID:    "db2",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -953,8 +973,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1033,8 +1055,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1116,8 +1140,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1191,7 +1217,13 @@ func TestUpdateCluster(t *testing.T) {
 						},
 					},
 				},
-				Proxy: &cluster.Proxy{},
+				Proxy: &cluster.Proxy{
+					Generation: 2,
+					Spec: cluster.ProxySpec{
+						MasterDBUID:    "",
+						EnabledProxies: []string{},
+					},
+				},
 			},
 		},
 		// #9 One master and one standby, 3 keepers (one available). Standby ok. No new standby db on free keeper created.
@@ -1281,8 +1313,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1371,8 +1405,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1462,8 +1498,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1572,8 +1610,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1685,8 +1725,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1774,8 +1816,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1859,8 +1903,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -1941,8 +1987,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -2004,8 +2052,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -2056,8 +2106,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -2153,8 +2205,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -2248,8 +2302,10 @@ func TestUpdateCluster(t *testing.T) {
 					},
 				},
 				Proxy: &cluster.Proxy{
+					Generation: 1,
 					Spec: cluster.ProxySpec{
-						MasterDBUID: "db1",
+						MasterDBUID:    "db1",
+						EnabledProxies: []string{},
 					},
 				},
 			},
@@ -2276,7 +2332,7 @@ func TestUpdateCluster(t *testing.T) {
 		fmt.Printf("test #%d\n", i)
 		t.Logf("test #%d", i)
 
-		outcd, err := s.updateCluster(tt.cd)
+		outcd, err := s.updateCluster(tt.cd, cluster.ProxiesInfo{})
 		if tt.err != nil {
 			if err == nil {
 				t.Errorf("got no error, wanted error: %v", tt.err)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -550,13 +550,11 @@ type DB struct {
 }
 
 type ProxySpec struct {
-	MasterDBUID string `json:"masterDbUid,omitempty"`
+	MasterDBUID    string   `json:"masterDbUid,omitempty"`
+	EnabledProxies []string `json:"enabledProxies,omitempty"`
 }
 
 type ProxyStatus struct {
-	// TODO(sgotti) register current active proxies status. Useful
-	// if in future we want to wait for all proxies having converged
-	// before enabling new master
 }
 
 type Proxy struct {

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -128,7 +128,6 @@ func (p ProxiesInfo) Less(i, j int) bool { return p[i].UID < p[j].UID }
 func (p ProxiesInfo) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 type ProxyInfo struct {
-	UID             string
-	ProxyUID        string
-	ProxyGeneration int64
+	UID        string
+	Generation int64
 }

--- a/tests/integration/proxy_test.go
+++ b/tests/integration/proxy_test.go
@@ -47,7 +47,7 @@ func TestProxyListening(t *testing.T) {
 	}
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
-	tp, err := NewTestProxy(t, dir, clusterName, tstore.storeBackend, storeEndpoints)
+	tp, err := NewTestProxy(t, dir, clusterName, pgSUUsername, pgSUPassword, tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}


### PR DESCRIPTION

This patch waits for proxies to report that they closed connections to
an unelected master before enabling connections to the new one.

This tries to avoid a small windows where a proxy can send data to
an unelected master when a new master is already active and other
proxies are already sending connection to it causing some transactions to
go to the right master while other to the old one since the proxy hasn't
yet read from the store to close its connections.

This could happen only when the failover is faster than the proxy
timeout and this isn't usually the case.

This is done reading the proxyInfo reported by the proxy to check if
they are at the right proxy generation.

If a proxy isn't reporting its proxyInfo (problems
talking to the store, partitioned etc...) the proxyInfo will expire and
the sentinel will go ahead assuming that the proxy has closed its
connection (due to internal proxy timeout).

This is the best we can do and it's done assuming that the proxy is
behaving correctly closing the connections after the proxy timeout. One
case that could break this rule is when the host is very loaded and the
processes are starved causing the timeout fire and pollon closing the
connection after more time, but in this case we can assume that also the
connection proxying should be starved in the same way. This can be
called as a self-fencing. The unique way to be sure that this won't
happen will be to do real fencing of the proxy (for example killing
the proxy process).

In addition only proxies marked as enabled in the cluster data will
proxy connections. This check enforces that only proxy already known by
the sentinel and marked by it as enabled will proxy connections, in this
way if during election of a new master a new proxy starts and reads from
the cluster data to proxy to the unelected master it will not do this
since the sentinel haven't marked it as enabled.