### PR TITLE
*: detect if standby can't sync due to missing wals

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -564,7 +564,8 @@ func (p *PostgresKeeper) GetPGState(pctx context.Context) (*cluster.PostgresStat
 		// if timeline <= 1 then no timeline history file exists.
 		pgState.TimelinesHistory = cluster.PostgresTimelinesHistory{}
 		if pgState.TimelineID > 1 {
-			tlsh, err := p.pgm.GetTimelinesHistory(pgState.TimelineID)
+			var tlsh []*postgresql.TimelineHistory
+			tlsh, err = p.pgm.GetTimelinesHistory(pgState.TimelineID)
 			if err != nil {
 				log.Errorw("error getting timeline history", zap.Error(err))
 				return pgState, nil
@@ -580,6 +581,14 @@ func (p *PostgresKeeper) GetPGState(pctx context.Context) (*cluster.PostgresStat
 				ctlsh = append(ctlsh, ctlh)
 			}
 			pgState.TimelinesHistory = ctlsh
+		}
+
+		ow, err := p.pgm.OlderWalFile()
+		if err != nil {
+			log.Warnw("error getting older wal file", zap.Error(err))
+		} else {
+			log.Debugw("older wal file", "filename", ow)
+			pgState.OlderWalFile = ow
 		}
 		pgState.Healthy = true
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -47,6 +47,8 @@ const (
 	DefaultProxyCheckInterval   = 5 * time.Second
 	DefaultProxyTimeoutInterval = 15 * time.Second
 
+	DefaultDBNotIncreasingXLogPosTimes = 10
+
 	DefaultSleepInterval                         = 5 * time.Second
 	DefaultRequestTimeout                        = 10 * time.Second
 	DefaultConvergenceTimeout                    = 30 * time.Second
@@ -537,6 +539,7 @@ type DBStatus struct {
 
 	PGParameters        PGParameters `json:"pgParameters,omitempty"`
 	SynchronousStandbys []string     `json:"synchronousStandbys"`
+	OlderWalFile        string       `json:"olderWalFile,omitempty"`
 }
 
 type DB struct {

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -88,13 +88,16 @@ type PostgresState struct {
 	ListenAddress string `json:"listenAddress,omitempty"`
 	Port          string `json:"port,omitempty"`
 
-	Healthy             bool                     `json:"healthy,omitempty"`
-	SystemID            string                   `json:"systemID,omitempty"`
-	TimelineID          uint64                   `json:"timelineID,omitempty"`
-	XLogPos             uint64                   `json:"xLogPos,omitempty"`
-	TimelinesHistory    PostgresTimelinesHistory `json:"timelinesHistory,omitempty"`
-	PGParameters        common.Parameters        `json:"pgParameters,omitempty"`
-	SynchronousStandbys []string                 `json:"synchronousStandbys"`
+	Healthy bool `json:"healthy,omitempty"`
+
+	SystemID         string                   `json:"systemID,omitempty"`
+	TimelineID       uint64                   `json:"timelineID,omitempty"`
+	XLogPos          uint64                   `json:"xLogPos,omitempty"`
+	TimelinesHistory PostgresTimelinesHistory `json:"timelinesHistory,omitempty"`
+
+	PGParameters        common.Parameters `json:"pgParameters,omitempty"`
+	SynchronousStandbys []string          `json:"synchronousStandbys"`
+	OlderWalFile        string            `json:"olderWalFile,omitempty"`
 }
 
 func (p *PostgresState) DeepCopy() *PostgresState {

--- a/pkg/postgresql/utils_test.go
+++ b/pkg/postgresql/utils_test.go
@@ -205,3 +205,40 @@ func TestParseVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestIsWalFileName(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"000000000000000000000000", true},
+		{"ABCDEF0123456789ABCDEF00", true},
+		{"", false},
+		{"ABCDEF0123456789ABCDEF0", false},
+		{"$123", false},
+	}
+
+	for i, tt := range tests {
+		valid := IsWalFileName(tt.name)
+		if valid != tt.valid {
+			t.Errorf("%d: wal filename %q got valid: %t but wanted valid: %t", i, tt.name, valid, tt.valid)
+		}
+	}
+}
+
+func TestWalFileNameNoTimeLine(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+	}{
+		{"000000000000000000000000", "0000000000000000"},
+		{"ABCDEF0123456789ABCDEF00", "23456789ABCDEF00"},
+	}
+
+	for i, tt := range tests {
+		out, _ := WalFileNameNoTimeLine(tt.name)
+		if out != tt.out {
+			t.Errorf("%d: wal filename %q got: %s but wanted: %s", i, tt.name, out, tt.out)
+		}
+	}
+}

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -123,18 +123,8 @@ func TestPITR(t *testing.T) {
 	}
 
 	// Switch wal so they will be archived
-	maj, _, err := tk.PGDataVersion()
-	if err != nil {
+	if err := tk.SwitchWals(1); err != nil {
 		t.Fatalf("unexpected err: %v", err)
-	}
-	if maj < 10 {
-		if _, err := tk.db.Exec("select pg_switch_xlog()"); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-	} else {
-		if _, err := tk.db.Exec("select pg_switch_wal()"); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
 	}
 
 	ts.Stop()


### PR DESCRIPTION
This patch detects if a standby won't be able to sync with master due to
missing wals.

Also if using replication slots this may happen since replication slots
are created only on the master so if a standby is down and a new
standby is elected as master it may not have all the wals needed by the
other standbys.

Since looks like the unique way to see if an instance cannot sync is to
parse logs for lines like:

FATAL:  could not receive data from WAL stream: ERROR:  requested WAL segment 000000010000000000000004 has already been removed

and parsing postgres logs will be error prone, we use another approach:

* Make the keepers report the older log files available in the
pg_xlog/pg_wal dir
* if a standby isn't syncing check if the required wal file name
is older than the older one available on the master. If so remove the db
from the cluster view so a new one could be readded.

Also add related integration tests.