### PR TITLE
scripts: Use `/usr/bin/env bash` instead of `/bin/bash`.

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test
+++ b/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Test script code thanks to coreos/etcd
 #


### PR DESCRIPTION
Same approach as is common for python.

Fixes builds on NixOS and other environments that guarantee
reproducible builds.