### PR TITLE
keeper: use unix domain socket for keeper postgres connection.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -31,6 +31,8 @@ const (
 	SentinelLeaderKey = "sentinel-leader"
 )
 
+const PgUnixSocketDirectories = "/tmp"
+
 type Role string
 
 const (

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -1436,6 +1436,8 @@ func TestKeeperRemoval(t *testing.T) {
 }
 
 func TestStandbyCantSync(t *testing.T) {
+	t.Parallel()
+
 	dir, err := ioutil.TempDir("", "stolon")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)


### PR DESCRIPTION
* The default pg_hba entries for local normal and replication
connections are stricter and the minimal required for keepers
connections.

This is the initial work for supporting custom pg_hba entries.
