### PR TITLE
travis: update go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.7.5
-  - 1.8.1
+  - 1.8.x
+  - 1.9.x
 
 env:
   - TARGET=amd64
@@ -12,4 +12,4 @@ install:
   -
 
 script:
-        ./test
+  ./test


### PR DESCRIPTION
Remove go 1.7 and add go 1.9 using .x versions.