### PR TITLE
postgres: also fetch wals during pg_basebackup

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -725,7 +725,7 @@ func (p *Manager) SyncFromFollowed(followedConnParams ConnParams) error {
 
 	log.Infow("running pg_basebackup")
 	name := filepath.Join(p.pgBinPath, "pg_basebackup")
-	cmd := exec.Command(name, "-R", "-D", p.dataDir, "-d", followedConnString)
+	cmd := exec.Command(name, "-R", "-Xf", "-D", p.dataDir, "-d", followedConnString)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSFILE=%s", pgpass.Name()))
 	log.Debugw("execing cmd", "cmd", cmd)
 


### PR DESCRIPTION
Also fetch wals when calling pg_basebackup. We could also stream them but this
will require an additional connection and wal sender so for now, since we are
using replication slots, just rely on fetching at the end of the basebackup.

This will fix pg_basebackup waiting indefinetly if archive mode is enabled but
the archive command on the primary isn't working correctly.