### PR TITLE
Add waitFullRecovery option to PITR

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -1073,7 +1073,14 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				log.Errorw("failed to start instance", zap.Error(err))
 				return
 			}
-			// wait for the db having replyed all the wals
+
+			if standbySettings == nil {
+				// wait for the db having replyed all the wals
+				if err = pgm.WaitRecoveryDone(cd.Cluster.DefSpec().SyncTimeout.Duration); err != nil {
+					log.Errorw("recovery not finished", zap.Error(err))
+					return
+				}
+			}
 			if err = pgm.WaitReady(cd.Cluster.DefSpec().SyncTimeout.Duration); err != nil {
 				log.Errorw("instance not ready", zap.Error(err))
 				return

--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -341,6 +341,21 @@ func (p *Manager) WaitReady(timeout time.Duration) error {
 	return fmt.Errorf("timeout waiting for db ready")
 }
 
+func (p *Manager) WaitRecoveryDone(timeout time.Duration) error {
+	start := time.Now()
+	for time.Now().Add(-timeout).Before(start) {
+		_, err := os.Stat(filepath.Join(p.dataDir, "recovery.done"))
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if !os.IsNotExist(err) {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for db recovery")
+}
+
 func (p *Manager) Promote() error {
 	log.Infow("promoting database")
 	name := filepath.Join(p.pgBinPath, "pg_ctl")


### PR DESCRIPTION
When restoring with PITR (at least with WAL-E), stolon-keeper do not wait until full recovery before marking itself as initialized.
This allow for read-only connection on a database that is still recovering and thus allow client to see outdated content.

Step to reproduce:
* Configure a cluster with WAL-E backup
* Create a custom table, insert data
* Generate WAL, using pgbench for example
* Update data from custom table
* Trigger a PITR recovery. To help seeing the issue, adding a sleep in the restoreCommand may help
* During the recovery, once Postgres reach consistent state, stolon will accept connection. Querying the custom table will allow to see initial inserted data.

I've made this an option because I'm not sure if it was intended or not to allow read-only connection during the recovery.