### PR TITLE
tests: lower TestStandbyCantSync disk usage

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -353,6 +353,11 @@ func (tk *TestKeeper) SwitchWals(times int) error {
 	return nil
 }
 
+func (tk *TestKeeper) CheckPoint() error {
+	_, err := tk.Exec("CHECKPOINT")
+	return err
+}
+
 func (tk *TestKeeper) WaitDBUp(timeout time.Duration) error {
 	start := time.Now()
 	for time.Now().Add(-timeout).Before(start) {


### PR DESCRIPTION
avoid wasting too much disk space doing less wal switches and cleaning unneeded
wals (using low values for min_wal_size and max_wal_size).