### PR TITLE
keeper: improve db start logic

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -1005,6 +1005,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 					log.Errorw("failed to start instance", zap.Error(err))
 					return
 				}
+				if err = pgm.WaitReady(cluster.DefaultDBWaitReadyTimeout); err != nil {
+					log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
+					return
+				}
 				pgParameters, err = pgm.GetConfigFilePGParameters()
 				if err != nil {
 					log.Errorw("failed to retrieve postgres parameters", zap.Error(err))
@@ -1016,6 +1020,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 			} else {
 				if err = pgm.StartTmpMerged(); err != nil {
 					log.Errorw("failed to start instance", zap.Error(err))
+					return
+				}
+				if err = pgm.WaitReady(cluster.DefaultDBWaitReadyTimeout); err != nil {
+					log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
 					return
 				}
 			}
@@ -1083,7 +1091,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 			}
 			// wait for the db having replyed all the wals
 			if err = pgm.WaitReady(cd.Cluster.DefSpec().SyncTimeout.Duration); err != nil {
-				log.Errorw("instance not ready", zap.Error(err))
+				log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
 				return
 			}
 
@@ -1179,7 +1187,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				return
 			}
 			if err = pgm.Start(); err != nil {
-				log.Errorw("err", zap.Error(err))
+				log.Errorw("failed to start instance", zap.Error(err))
 				return
 			}
 			started = true
@@ -1188,7 +1196,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				fullResync := false
 				// if not accepting connection assume that it's blocked waiting for missing wal
 				// (see above TODO), so do a full resync using pg_basebackup.
-				if err = pgm.Ping(); err != nil {
+				if err = pgm.WaitReady(cluster.DefaultDBWaitReadyTimeout); err != nil {
 					log.Errorw("pg_rewinded standby is not accepting connection. it's probably waiting for unavailable wals. Forcing a full resync")
 					fullResync = true
 				} else {
@@ -1250,6 +1258,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 					log.Errorw("failed to start instance", zap.Error(err))
 					return
 				}
+				if err = pgm.WaitReady(cluster.DefaultDBWaitReadyTimeout); err != nil {
+					log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
+					return
+				}
 				pgParameters, err = pgm.GetConfigFilePGParameters()
 				if err != nil {
 					log.Errorw("failed to retrieve postgres parameters", zap.Error(err))
@@ -1261,6 +1273,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 			} else {
 				if err = pgm.StartTmpMerged(); err != nil {
 					log.Errorw("failed to start instance", zap.Error(err))
+					return
+				}
+				if err = pgm.WaitReady(cluster.DefaultDBWaitReadyTimeout); err != nil {
+					log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
 					return
 				}
 			}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -47,6 +47,8 @@ const (
 	DefaultProxyCheckInterval   = 5 * time.Second
 	DefaultProxyTimeoutInterval = 15 * time.Second
 
+	DefaultDBWaitReadyTimeout = 60 * time.Second
+
 	DefaultDBNotIncreasingXLogPosTimes = 10
 
 	DefaultSleepInterval                         = 5 * time.Second


### PR DESCRIPTION
Unfortunately pg_ctl start changed behavior in postgresql 10:

pg_ctl for postgres < 10 with -w will returns 0 also if the instance isn't ready
to accept connections.

While in postgres >= 10 it will return a non 0 exit code (1 like when the
instance fails to start) making it impossible to distinguish between problems
starting an instance (i.e. wrong parameters) or an instance started but not
ready to accept connections.

To work with all the versions and since we want to distinguish between a failed
start and a started but not ready instance we are forced to not use pg_ctl and
write part of its logic here (I hate to do this).

Now PGManager.start method directly starts the instance using the "postgres"
executable and waits 1 minute to see if the process starts (checking its pid file)
or exits due to an error. It doesn't check if the instance is ready to accept
connections. When needed this is done inside the keeper calling WaitReady.
  