### PR TITLE
keeper: fix datadir locking

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -1730,4 +1730,6 @@ func keeper(c *cobra.Command, args []string) {
 	go p.Start(ctx)
 
 	<-end
+
+	lockFile.Close()
 }


### PR DESCRIPTION
lockFile wasn't referenced and so the gc will collect it and close its
file descriptor releasing the lock.

To keep it referenced just explicitly Close lockFile before exiting.