### PR TITLE
build: allow explicit version configuration

### DIFF
--- a/build
+++ b/build
@@ -43,7 +43,7 @@ mkdir -p ${BINDIR}
 
 export GO15VENDOREXPERIMENT=1
 
-VERSION=$(${BASEDIR}/scripts/git-version.sh)
+VERSION=${STOLON_VERSION:-$(${BASEDIR}/scripts/git-version.sh)}
 LD_FLAGS="-s -X ${REPO_PATH}/cmd.Version=$VERSION"
 
 # for static compilation we need to compile with cgo disabled (CGO_ENABLED=0),


### PR DESCRIPTION
When using source tarball, builds fail when discovering current version. This change allows for STOLON_VERSION, if set in the environment, to be used as the build version instead of attempting discovery.

The original issue was identified when building v0.8.0 RPMs. See [source](https://github.com/abn/stolon-rpm) for current workaround.