### PR TITLE
keeper: add some missing waits for instance ready

### DIFF
--- a/cmd/keeper/keeper.go
+++ b/cmd/keeper/keeper.go
@@ -1349,6 +1349,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 				log.Errorw("failed to start postgres", zap.Error(err))
 				return
 			}
+			if err = pgm.WaitReady(cluster.DefaultDBWaitReadyTimeout); err != nil {
+				log.Errorw("timeout waiting for instance to be ready", zap.Error(err))
+				return
+			}
 			started = true
 		}
 


### PR DESCRIPTION
When we start an instance during the main logic we should wait that
it's ready (or the next command to update its replication slots will fail).