### PR TITLE
sentinel: handle stale proxyInfos

### DIFF
--- a/cmd/stolonctl/status.go
+++ b/cmd/stolonctl/status.go
@@ -127,6 +127,7 @@ func status(cmd *cobra.Command, args []string) {
 	if err != nil {
 		die("cannot get proxies info: %v", err)
 	}
+	proxiesInfoSlice := proxiesInfo.ToSlice()
 
 	stdout("")
 	stdout("=== Active proxies ===")
@@ -134,9 +135,9 @@ func status(cmd *cobra.Command, args []string) {
 	if len(proxiesInfo) == 0 {
 		stdout("No active proxies")
 	} else {
-		sort.Sort(proxiesInfo)
+		sort.Sort(proxiesInfoSlice)
 		fmt.Fprintf(tabOut, "ID\n")
-		for _, pi := range proxiesInfo {
+		for _, pi := range proxiesInfoSlice {
 			fmt.Fprintf(tabOut, "%s\n", pi.UID)
 			tabOut.Flush()
 		}

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -124,13 +124,41 @@ type SentinelInfo struct {
 	UID string
 }
 
-type ProxiesInfo []*ProxyInfo
-
-func (p ProxiesInfo) Len() int           { return len(p) }
-func (p ProxiesInfo) Less(i, j int) bool { return p[i].UID < p[j].UID }
-func (p ProxiesInfo) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
 type ProxyInfo struct {
+	// An unique id for this info, used to know when the proxy info
+	// has been updated
+	InfoUID string `json:"infoUID,omitempty"`
+
 	UID        string
 	Generation int64
 }
+
+type ProxiesInfo map[string]*ProxyInfo
+
+func (p ProxiesInfo) DeepCopy() ProxiesInfo {
+	if p == nil {
+		return nil
+	}
+	np, err := copystructure.Copy(p)
+	if err != nil {
+		panic(err)
+	}
+	if !reflect.DeepEqual(p, np) {
+		panic("not equal")
+	}
+	return np.(ProxiesInfo)
+}
+
+func (p ProxiesInfo) ToSlice() ProxiesInfoSlice {
+	pis := ProxiesInfoSlice{}
+	for _, pi := range p {
+		pis = append(pis, pi)
+	}
+	return pis
+}
+
+type ProxiesInfoSlice []*ProxyInfo
+
+func (p ProxiesInfoSlice) Len() int           { return len(p) }
+func (p ProxiesInfoSlice) Less(i, j int) bool { return p[i].UID < p[j].UID }
+func (p ProxiesInfoSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -448,7 +448,7 @@ func (s *Store) GetProxiesInfo(ctx context.Context) (cluster.ProxiesInfo, error)
 		if err != nil {
 			return nil, err
 		}
-		psi = append(psi, &pi)
+		psi[pi.UID] = &pi
 	}
 	return psi, nil
 }

--- a/tests/integration/sentinel_test.go
+++ b/tests/integration/sentinel_test.go
@@ -1,0 +1,166 @@
+// Copyright 2017 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/sorintlab/stolon/common"
+	"github.com/sorintlab/stolon/pkg/cluster"
+	"github.com/sorintlab/stolon/pkg/store"
+)
+
+func TestSentinelEnabledProxies(t *testing.T) {
+	t.Parallel()
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	tstore := setupStore(t, dir)
+	defer tstore.Stop()
+
+	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
+
+	clusterName := uuid.NewV4().String()
+
+	storePath := filepath.Join(common.StorePrefix, clusterName)
+	sm := store.NewStore(tstore.store, storePath)
+
+	initialClusterSpec := &cluster.ClusterSpec{
+		InitMode:           cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
+		SleepInterval:      &cluster.Duration{Duration: 2 * time.Second},
+		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
+		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
+		PGParameters:       defaultPGParameters,
+	}
+	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	ts, err := NewTestSentinel(t, dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--initial-cluster-spec=%s", initialClusterSpecFile))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := ts.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	defer ts.Stop()
+	tk, err := NewTestKeeper(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	defer tk.Stop()
+
+	tp, err := NewTestProxy(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tp.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	waitKeeperReady(t, sm, tk)
+
+	// the proxy should connect to the right master
+	if err := tp.WaitRightMaster(tk, 3*cluster.DefaultProxyCheckInterval); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	t.Logf("stopping sentinel")
+	ts.Stop()
+
+	cd, _, err := sm.GetClusterData(context.TODO())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	enabledProxies := cd.Proxy.Spec.EnabledProxies
+
+	t.Logf("starting sentinel")
+	ts.Start()
+
+	// check that the sentinel has become leader (cluster data is changed since
+	// it's updating keepers status) TODO(sgotti) find a better way to determine
+	// if the sentinel is the leader and is updating the clusterdata
+	if err := WaitClusterDataUpdated(sm, 30*time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	t.Logf("clusterdata changed")
+
+	// check that the enabled proxies aren't changed (same Proxy Generation and same EnabledProxies)
+	cd, _, err = sm.GetClusterData(context.TODO())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if !reflect.DeepEqual(enabledProxies, cd.Proxy.Spec.EnabledProxies) {
+		t.Fatalf("expected enabled proxies: %q, got: %q", enabledProxies, cd.Proxy.Spec.EnabledProxies)
+	}
+
+	// add another proxy
+	tp2, err := NewTestProxy(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tp2.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	// the proxy should connect to the right master
+	if err := tp2.WaitRightMaster(tk, 3*cluster.DefaultProxyCheckInterval); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := WaitClusterDataEnabledProxiesNum(sm, 2, 3*initialClusterSpec.SleepInterval.Duration); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	// freeze the proxy
+	t.Logf("SIGSTOPping proxy: %s", tp2.uid)
+	if err := tp2.Signal(syscall.SIGSTOP); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := WaitClusterDataEnabledProxiesNum(sm, 1, 3*cluster.DefaultProxyTimeoutInterval); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	// unfreeze the proxy
+	t.Logf("SIGCONTing proxy: %s", tp2.uid)
+	if err := tp2.Signal(syscall.SIGCONT); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := WaitClusterDataEnabledProxiesNum(sm, 2, 3*initialClusterSpec.SleepInterval.Duration); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}


### PR DESCRIPTION
Don't rely on proxyInfos being expired by the store but handle this at the
sentinel level. Like already done for the keepers check that the published
proxyInfo is updated by checking that the published InfoUID is changed or ignore
it if it's not updated for a specified time interval (assuming that the proxy
stopped listening in this interval).

This is also needed for future kubernetes based store where the proxyInfos is
read from the pod and under some error conditions it won't expire but just not
being updated.

Also improve the proxy spec update logic in updateCluster to only check for
converged proxies when a new master is elected (the proxies spec master is
empty)