### PR TITLE
sentinel: improve sync standby management logic

### DIFF
--- a/pkg/util/slice.go
+++ b/pkg/util/slice.go
@@ -23,7 +23,7 @@ func StringInSlice(s []string, e string) bool {
 	return false
 }
 
-// CompareStringSlice compares two slices of strings, an nil slice is considered an empty one
+// CompareStringSlice compares two slices of strings, a nil slice is considered an empty one
 func CompareStringSlice(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
@@ -35,4 +35,15 @@ func CompareStringSlice(a []string, b []string) bool {
 		}
 	}
 	return true
+}
+
+// CommonElements return the common elements in two slices of strings
+func CommonElements(a []string, b []string) []string {
+	common := []string{}
+	for _, v := range a {
+		if StringInSlice(b, v) {
+			common = append(common, v)
+		}
+	}
+	return common
 }


### PR DESCRIPTION
* Update the sync standbys only if the reported ones are the same as the required
ones. In this way, when we have to choose a new master we are sure that there're
no intermediate changes between the reported standbys and the required ones.

* When we have to choose a new sync standby as master we can just choose one of
the common standbys between the reported and the required one since we are sure
these are defined in the master as sync standbys

* Improve logic to always have some real sync standbys up to
MinSynchronousStanbys, also if not in good state, to improve the possibility
to be able to choose a sync standby to replace a failed master.

* Always keep a common standby between the previous and the wanted
synchronousStandbys