### PR TITLE
travis: update go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
+  - 1.10.x
 
 env:
   - TARGET=amd64


### PR DESCRIPTION
Remove go 1.8.x and add go 1.10.x