### PR TITLE
tests: disable caching in integration tests

### DIFF
--- a/test
+++ b/test
@@ -123,7 +123,7 @@ if [ -n "$INTEGRATION" ]; then
 	fi
 
 	[ -z "$PARALLEL" ] && PARALLEL=4
-	go test -timeout 20m $@ -v -parallel ${PARALLEL} ${REPO_PATH}/tests/integration
+	go test -timeout 20m $@ -v -count 1 -parallel ${PARALLEL} ${REPO_PATH}/tests/integration
 fi
 
 echo "Success"


### PR DESCRIPTION
With go 1.10 integration tests will returns cached results since no test
code has changed.

Disable caching using the `-count 1` option.