### PR TITLE
keeper: stop running instance when db not assigned.

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -942,6 +942,9 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	db := cd.FindDB(k)
 	if db == nil {
 		log.Infow("no db assigned")
+		if err = pgm.StopIfStarted(true); err != nil {
+			log.Errorw("failed to stop pg instance", zap.Error(err))
+		}
 		return
 	}
 


### PR DESCRIPTION
If the sentinel removes a db from the clusterdata, the related keeper should
stop the instance (currently we keep the data).