### PR TITLE
k8s store: fix wrong namespace used for election events

### DIFF
--- a/pkg/store/k8s.go
+++ b/pkg/store/k8s.go
@@ -389,7 +389,7 @@ func NewKubeElection(kubecli *kubernetes.Clientset, podName, namespace, clusterN
 		kubecli.CoreV1(),
 		resourcelock.ResourceLockConfig{
 			Identity:      candidateUID,
-			EventRecorder: createRecorder(kubecli, "stolon-sentinel", "default"),
+			EventRecorder: createRecorder(kubecli, "stolon-sentinel", namespace),
 		})
 	if err != nil {
 		return nil, fmt.Errorf("error creating lock: %v", err)


### PR DESCRIPTION
The event recorder namespace was set to `default` instead of using the right one.