### PR TITLE
k8s store: use component label instead of app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v0.11.0
+
+* In the k8s store backend, stolon components discovery now uses the `component` label instead of the `app` label.
+
+## Upgrades notes.
+
+In the k8s store backend, the label that defines the kind of stolon component has changed from `app` to `component`. When upgrading you should update the various resource descriptors setting the k8s component name (`stolon-keeper`, `stolon-sentinel`, `stolon-proxy`) inside the `component` label instead of the `app` label.
+
 ### v0.10.0
 
 #### New features

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -53,7 +53,7 @@ To store the clusterdata and handle sentinel leader election a configmap resourc
 
 To discovery stolon components (keepers, proxies, sentinels) a lookup with specific label selectors is executed. These labels must be correctly set on the pod definition (see the [kubernetes example](/examples/kubernetes)). They are:
 
-`app` set to the component type: `stolon-keeper`, `stolon-sentinel`, `stolon-proxy`
+`component` set to the component type: `stolon-keeper`, `stolon-sentinel`, `stolon-proxy`
 `stolon-cluster` set to the stolon cluster name
 
 Every components also saves its state in an annotation of their own pod called `stolon-status`

--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        app: stolon-keeper
+        component: stolon-keeper
         stolon-cluster: kube-stolon
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"

--- a/examples/kubernetes/stolon-proxy-service.yaml
+++ b/examples/kubernetes/stolon-proxy-service.yaml
@@ -7,5 +7,5 @@ spec:
     - port: 5432
       targetPort: 5432
   selector:
-    app: stolon-proxy
+    component: stolon-proxy
     stolon-cluster: kube-stolon

--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        app: stolon-proxy
+        component: stolon-proxy
         stolon-cluster: kube-stolon
     spec:
       containers:

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        app: stolon-sentinel
+        component: stolon-sentinel
         stolon-cluster: kube-stolon
     spec:
       containers:

--- a/pkg/store/k8s.go
+++ b/pkg/store/k8s.go
@@ -39,7 +39,7 @@ import (
 type ComponentLabelValue string
 
 const (
-	DefaultComponentLabel = "app"
+	DefaultComponentLabel = "component"
 
 	KeeperLabelValue   ComponentLabelValue = "stolon-keeper"
 	SentinelLabelValue ComponentLabelValue = "stolon-sentinel"


### PR DESCRIPTION
Use `component` label instead off `app` label to filter pods.

The `app` label is usually used to reflect the entire app (for example see
helm label best practices:
https://github.com/kubernetes/helm/blob/master/docs/chart_best_practices/labels.md)

Fixes #466 

/cc @Flowkap @lwolf