### PR TITLE
keeper: remove postgresql.auto.conf before pg_rewind

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -803,6 +803,12 @@ func (p *Manager) createPostgresqlAutoConf() error {
 }
 
 func (p *Manager) SyncFromFollowedPGRewind(followedConnParams ConnParams, password string) error {
+	// Remove postgresql.auto.conf since pg_rewind will error if it's a symlink to /dev/null
+	pgAutoConfPath := filepath.Join(p.dataDir, postgresAutoConf)
+	if err := os.Remove(pgAutoConfPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error removing postgresql.auto.conf file: %v", err)
+	}
+
 	// ioutil.Tempfile already creates files with 0600 permissions
 	pgpass, err := ioutil.TempFile("", "pgpass")
 	if err != nil {


### PR DESCRIPTION
pg_rewind isn't happy if the postgresql.auto.conf on the target instance is a
symlink to /dev/null. So remove it before calling pg_rewind.

Fixes #468 

/cc @deepdivenow 