### PR TITLE
tests: set minikube version to v0.25.2

### DIFF
--- a/scripts/semaphore-k8s.sh
+++ b/scripts/semaphore-k8s.sh
@@ -13,7 +13,7 @@ fi
 rm -rf ~/.rbenv ~/.php*
 
 # Install kubectl and minikube
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/
+curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo cp minikube /usr/local/bin/
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo cp kubectl /usr/local/bin/
 
 # Start local minikube


### PR DESCRIPTION
v0.26.0 with vm driver set to none doesn't work on semaphore vm since they don't
use systemd.