### PR TITLE
add missing resource type

### DIFF
--- a/examples/kubernetes/role.yaml
+++ b/examples/kubernetes/role.yaml
@@ -17,5 +17,6 @@ rules:
   resources:
   - pods
   - configmaps
+  - events
   verbs:
   - "*"


### PR DESCRIPTION
Resolves a permission error that occurs on sentinel startup.