### PR TITLE
Added ability to set different volume/path for pg_data directory

### DIFF
--- a/pkg/postgresql/postgresql.go
+++ b/pkg/postgresql/postgresql.go
@@ -96,7 +96,7 @@ func SetLogger(l *zap.SugaredLogger) {
 func NewManager(pgBinPath string, dataDir string, localConnParams, replConnParams ConnParams, suAuthMethod, suUsername, suPassword, replAuthMethod, replUsername, replPassword string, requestTimeout time.Duration) *Manager {
 	return &Manager{
 		pgBinPath:       pgBinPath,
-		dataDir:         filepath.Join(dataDir, "postgres"),
+		dataDir:         dataDir,
 		parameters:      make(common.Parameters),
 		curParameters:   make(common.Parameters),
 		replConnParams:  replConnParams,
@@ -179,7 +179,7 @@ func (p *Manager) Init(initConfig *InitConfig) error {
 	}
 	// remove the dataDir, so we don't end with an half initialized database
 	if err != nil {
-		os.RemoveAll(p.dataDir)
+		removeDirContents(p.dataDir)
 		return err
 	}
 	return nil
@@ -208,7 +208,7 @@ func (p *Manager) Restore(command string) error {
 	// On every error remove the dataDir, so we don't end with an half initialized database
 out:
 	if err != nil {
-		os.RemoveAll(p.dataDir)
+		removeDirContents(p.dataDir)
 		return err
 	}
 	return nil
@@ -879,7 +879,7 @@ func (p *Manager) RemoveAll() error {
 	if started {
 		return fmt.Errorf("cannot remove postregsql database. Instance is active")
 	}
-	return os.RemoveAll(p.dataDir)
+	return removeDirContents(p.dataDir)
 }
 
 func (p *Manager) GetSystemData() (*SystemData, error) {

--- a/pkg/postgresql/utils.go
+++ b/pkg/postgresql/utils.go
@@ -19,13 +19,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/sorintlab/stolon/common"
-
-	"os"
 
 	_ "github.com/lib/pq"
 )
@@ -346,6 +346,25 @@ func fileExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func removeDirContents(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func expand(s, dataDir string) string {


### PR DESCRIPTION
This can be useful if you wish to run stolon with a setup that potentially has a different volume for the keeper data vs the postgres data. Default behavior would remain the same.

For example, one may want to use a ramdisk for the keeper data, while using a proper block storage device with a different configuration for the postgres data.... In a well operating stolon cluster, the cluster/keeper state data does not change very frequently, while the postgres data can change quite frequently.

The delete method had to change to support mounting separate volumes for keeper/db state data vs postgres data, because if you mount a volume for pg_data specifically, the folder can not be removed (must be unmounted) and the contents must be removed instead. If there is no interest in this, I can maintain a separate fork/patch for my own uses...