### PR TITLE
keeper: don't disable ssl for replication

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -220,7 +220,8 @@ func (p *PostgresKeeper) getSUConnParams(db, followedDB *cluster.DB) pg.ConnPara
 		"port":             followedDB.Status.Port,
 		"application_name": common.StolonName(db.UID),
 		"dbname":           "postgres",
-		"sslmode":          "disable",
+		// prefer ssl if available (already the default for postgres libpq but not for golang lib pq)
+		"sslmode": "prefer",
 	}
 	if p.pgSUAuthMethod != "trust" {
 		cp.Set("password", p.pgSUPassword)
@@ -234,7 +235,8 @@ func (p *PostgresKeeper) getReplConnParams(db, followedDB *cluster.DB) pg.ConnPa
 		"host":             followedDB.Status.ListenAddress,
 		"port":             followedDB.Status.Port,
 		"application_name": common.StolonName(db.UID),
-		"sslmode":          "disable",
+		// prefer ssl if available (already the default for postgres libpq but not for golang lib pq)
+		"sslmode": "prefer",
 	}
 	if p.pgReplAuthMethod != "trust" {
 		cp.Set("password", p.pgReplPassword)
@@ -244,11 +246,11 @@ func (p *PostgresKeeper) getReplConnParams(db, followedDB *cluster.DB) pg.ConnPa
 
 func (p *PostgresKeeper) getLocalConnParams() pg.ConnParams {
 	cp := pg.ConnParams{
-		"user":    p.pgSUUsername,
-		"host":    common.PgUnixSocketDirectories,
-		"port":    p.pgPort,
-		"dbname":  "postgres",
-		"sslmode": "disable",
+		"user":   p.pgSUUsername,
+		"host":   common.PgUnixSocketDirectories,
+		"port":   p.pgPort,
+		"dbname": "postgres",
+		// no sslmode defined since it's not needed and supported over unix sockets
 	}
 	if p.pgSUAuthMethod != "trust" {
 		cp.Set("password", p.pgSUPassword)
@@ -262,7 +264,7 @@ func (p *PostgresKeeper) getLocalReplConnParams() pg.ConnParams {
 		"password": p.pgReplPassword,
 		"host":     common.PgUnixSocketDirectories,
 		"port":     p.pgPort,
-		"sslmode":  "disable",
+		// no sslmode defined since it's not needed and supported over unix sockets
 	}
 	if p.pgReplAuthMethod != "trust" {
 		cp.Set("password", p.pgReplPassword)

--- a/doc/ssl.md
+++ b/doc/ssl.md
@@ -1,6 +1,6 @@
 ## PostgreSQL SSL/TLS setup
 
-SSL/TLS access to an HA postgres managed by stolon can be configured as usual (see the [official postgres doc](https://www.postgresql.org/docs/current/static/ssl-tcp.html)). The setup is done [defining the required pgParameters inside the cluster spec](postgres_parameters.md).
+SSL/TLS access to an HA postgres managed by stolon can be configured as usual (see the [official postgres doc](https://www.postgresql.org/docs/current/static/ssl-tcp.html)). The setup is done [defining the required pgParameters inside the cluster spec](postgres_parameters.md). If this is enabled also replication between instances will use tls (currently it'll use the default replication mode of "prefer").
 
 If you want to enable client side full verification (`sslmode=verify-full` in the client connection string) you should configure the certificate CN to contain the FQDN or IP address that your client will use to connect to the stolon proxies. Depending on your architecture you'll have more than one stolon proxies behind a load balancer, a keepealived ip, a k8s service etc... So the certificate CN should be set to the hostname or ip that your client will connect to.
 


### PR DESCRIPTION
Set sslmode to `prefer` so, if the user has enabled ssl/tls, it'll also be used for
replication (and pg_rewind).

Now it's not possible to force other options like verify-ca or verify-full since
they requires more effort on the user side and need to be carefully tested.