### PR TITLE
Removing carriage return from example secret

### DIFF
--- a/examples/kubernetes/secret.yaml
+++ b/examples/kubernetes/secret.yaml
@@ -5,4 +5,4 @@ metadata:
     name: stolon
 type: Opaque
 data:
-    password: cGFzc3dvcmQxCg==
+    password: cGFzc3dvcmQx


### PR DESCRIPTION
The example secret is encoded with a carriage return which causes problems with cluster auth when using the default example scripts. Although this password should be changed, users who want to quickly test out stolon in minikube will find that they are unable to authenticate into the cluster using password1.

Referring to #500 