### PR TITLE
*: syncrepl, consider only really in sync standbys

### DIFF
--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -631,10 +631,17 @@ type DBStatus struct {
 
 	PGParameters PGParameters `json:"pgParameters,omitempty"`
 
-	// DBUIDs of the internal standbys set as synchronous
+	// DBUIDs of the internal standbys currently reported as in sync by the instance
+	CurSynchronousStandbys []string `json:"-"`
+
+	// DBUIDs of the internal standbys that we know are in sync.
+	// They could be currently down but we know that they were reported as in
+	// sync in the past and they are defined inside synchronous_standby_names
+	// so the instance will wait for acknowledge from them.
+	SynchronousStandbys []string `json:"synchronousStandbys"`
+
 	// NOTE(sgotti) we currently don't report the external synchronous standbys.
 	// If/when needed lets add a new ExternalSynchronousStandbys field
-	SynchronousStandbys []string `json:"synchronousStandbys"`
 
 	OlderWalFile string `json:"olderWalFile,omitempty"`
 }

--- a/internal/postgresql/postgresql.go
+++ b/internal/postgresql/postgresql.go
@@ -532,6 +532,12 @@ func (p *Manager) SetupRoles() error {
 	return nil
 }
 
+func (p *Manager) GetSyncStandbys() ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), p.requestTimeout)
+	defer cancel()
+	return getSyncStandbys(ctx, p.localConnParams)
+}
+
 func (p *Manager) GetReplicationSlots() ([]string, error) {
 	maj, _, err := p.PGDataVersion()
 	if err != nil {

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -72,3 +72,14 @@ func CommonElements(a []string, b []string) []string {
 	}
 	return common
 }
+
+// Difference returns elements in a - b
+func Difference(a []string, b []string) []string {
+	diff := []string{}
+	for _, v := range a {
+		if !StringInSlice(b, v) {
+			diff = append(diff, v)
+		}
+	}
+	return diff
+}

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -67,3 +67,33 @@ func TestCompareStringSliceNoOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestDifference(t *testing.T) {
+	tests := []struct {
+		a []string
+		b []string
+		r []string
+	}{
+		{[]string{}, []string{}, []string{}},
+		{[]string{"", ""}, []string{""}, []string{}},
+		{[]string{"", ""}, []string{"", ""}, []string{}},
+		{[]string{"", ""}, []string{"a", "", "b"}, []string{}},
+		{[]string{"a", "b"}, []string{"a", "b"}, []string{}},
+		{[]string{"a", "b"}, []string{"b", "a"}, []string{}},
+		{[]string{"a", "b", "c"}, []string{}, []string{"a", "b", "c"}},
+		{[]string{"a", "b", "c"}, []string{"a", "b"}, []string{"c"}},
+		{[]string{"a", "b"}, []string{"a", "b", "c"}, []string{}},
+		{[]string{"a", "b"}, []string{"c", "a", "b"}, []string{}},
+		{[]string{"a", "b", "c"}, []string{"a", "b", "c"}, []string{}},
+		{[]string{"a", "b", "c"}, []string{"b", "c", "a"}, []string{}},
+		{[]string{"a", "b", "c", "a"}, []string{"a", "c", "b", "b"}, []string{}},
+		{[]string{"a", "b", "c", "a"}, []string{"a", "c", "b", "b"}, []string{}},
+	}
+
+	for i, tt := range tests {
+		r := Difference(tt.a, tt.b)
+		if !CompareStringSliceNoOrder(r, tt.r) {
+			t.Errorf("%d: got %v but wanted: %v a: %v, b: %v", i, r, tt.r, tt.a, tt.b)
+		}
+	}
+}


### PR DESCRIPTION
When using syncrepl don't consider a standby in sync only because it has been
added in the synchronous_standby_names parameter but only when the postgres
instance reports it as in sync (querying pg_stat_replication).