### PR TITLE
fixed listen address in SUReplAccessStrict

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1746,8 +1746,8 @@ func (p *PostgresKeeper) generateHBA(cd *cluster.ClusterData, db *cluster.DB) []
 				if dbElt.UID != db.UID {
 					computedHBA = append(
 						computedHBA,
-						fmt.Sprintf("host all %s %s/32 %s", p.pgSUUsername, db.Status.ListenAddress, p.pgReplAuthMethod),
-						fmt.Sprintf("host replication %s %s/32 %s", p.pgReplUsername, db.Status.ListenAddress, p.pgReplAuthMethod),
+						fmt.Sprintf("host all %s %s/32 %s", p.pgSUUsername, dbElt.Status.ListenAddress, p.pgReplAuthMethod),
+						fmt.Sprintf("host replication %s %s/32 %s", p.pgReplUsername, dbElt.Status.ListenAddress, p.pgReplAuthMethod),
 					)
 				}
 			}

--- a/cmd/keeper/cmd/keeper_test.go
+++ b/cmd/keeper/cmd/keeper_test.go
@@ -15,9 +15,14 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/sorintlab/stolon/internal/cluster"
+	"github.com/sorintlab/stolon/internal/common"
 )
 
 var curUID int
@@ -70,6 +75,161 @@ func TestParseSynchronousStandbyNames(t *testing.T) {
 			} else if !reflect.DeepEqual(out, tt.out) {
 				t.Errorf("%d: wrong output: got:\n%s\nwant:\n%s", i, out, tt.out)
 			}
+		}
+	}
+}
+
+func TestGenerateHBA(t *testing.T) {
+	// minimal clusterdata with only the fields used by generateHBA
+	cd := &cluster.ClusterData{
+		Cluster: &cluster.Cluster{
+			Spec:   &cluster.ClusterSpec{},
+			Status: cluster.ClusterStatus{},
+		},
+		Keepers: cluster.Keepers{},
+		DBs: cluster.DBs{
+			"db1": &cluster.DB{
+				UID: "db1",
+				Spec: &cluster.DBSpec{
+					Role: common.RoleMaster,
+				},
+				Status: cluster.DBStatus{
+					ListenAddress: "192.168.0.1",
+				},
+			},
+			"db2": &cluster.DB{
+				UID: "db2",
+				Spec: &cluster.DBSpec{
+					Role: common.RoleStandby,
+					FollowConfig: &cluster.FollowConfig{
+						Type:  cluster.FollowTypeInternal,
+						DBUID: "db1",
+					},
+				},
+				Status: cluster.DBStatus{
+					ListenAddress: "192.168.0.2",
+				},
+			},
+		},
+		Proxy: &cluster.Proxy{},
+	}
+
+	tests := []struct {
+		DefaultSUReplAccessMode cluster.SUReplAccessMode
+		dbUID                   string
+		pgHBA                   []string
+		out                     []string
+	}{
+		{
+			DefaultSUReplAccessMode: cluster.SUReplAccessAll,
+			dbUID: "db1",
+			out: []string{
+				"local postgres superuser md5",
+				"local replication repluser md5",
+				"host all superuser 0.0.0.0/0 md5",
+				"host all superuser ::0/0 md5",
+				"host replication repluser 0.0.0.0/0 md5",
+				"host replication repluser ::0/0 md5",
+				"host all all 0.0.0.0/0 md5",
+				"host all all ::0/0 md5",
+			},
+		},
+		{
+			DefaultSUReplAccessMode: cluster.SUReplAccessAll,
+			dbUID: "db2",
+			out: []string{
+				"local postgres superuser md5",
+				"local replication repluser md5",
+				"host all superuser 0.0.0.0/0 md5",
+				"host all superuser ::0/0 md5",
+				"host replication repluser 0.0.0.0/0 md5",
+				"host replication repluser ::0/0 md5",
+				"host all all 0.0.0.0/0 md5",
+				"host all all ::0/0 md5",
+			},
+		},
+		{
+			DefaultSUReplAccessMode: cluster.SUReplAccessAll,
+			dbUID: "db1",
+			pgHBA: []string{
+				"host all all 192.168.0.0/24 md5",
+			},
+			out: []string{
+				"local postgres superuser md5",
+				"local replication repluser md5",
+				"host all superuser 0.0.0.0/0 md5",
+				"host all superuser ::0/0 md5",
+				"host replication repluser 0.0.0.0/0 md5",
+				"host replication repluser ::0/0 md5",
+				"host all all 192.168.0.0/24 md5",
+			},
+		},
+		{
+			DefaultSUReplAccessMode: cluster.SUReplAccessAll,
+			dbUID: "db2",
+			pgHBA: []string{
+				"host all all 192.168.0.0/24 md5",
+			},
+			out: []string{
+				"local postgres superuser md5",
+				"local replication repluser md5",
+				"host all superuser 0.0.0.0/0 md5",
+				"host all superuser ::0/0 md5",
+				"host replication repluser 0.0.0.0/0 md5",
+				"host replication repluser ::0/0 md5",
+				"host all all 192.168.0.0/24 md5",
+			},
+		},
+		{
+			DefaultSUReplAccessMode: cluster.SUReplAccessStrict,
+			dbUID: "db1",
+			out: []string{
+				"local postgres superuser md5",
+				"local replication repluser md5",
+				"host all superuser 192.168.0.2/32 md5",
+				"host replication repluser 192.168.0.2/32 md5",
+				"host all all 0.0.0.0/0 md5",
+				"host all all ::0/0 md5",
+			},
+		},
+		{
+			DefaultSUReplAccessMode: cluster.SUReplAccessStrict,
+			dbUID: "db2",
+			out: []string{
+				"local postgres superuser md5",
+				"local replication repluser md5",
+				"host all all 0.0.0.0/0 md5",
+				"host all all ::0/0 md5",
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		p := &PostgresKeeper{
+			pgSUAuthMethod:   "md5",
+			pgSUUsername:     "superuser",
+			pgReplAuthMethod: "md5",
+			pgReplUsername:   "repluser",
+		}
+
+		cd.Cluster.Spec.DefaultSUReplAccessMode = &tt.DefaultSUReplAccessMode
+
+		db := cd.DBs[tt.dbUID]
+		db.Spec.PGHBA = tt.pgHBA
+
+		out := p.generateHBA(cd, db)
+
+		if !reflect.DeepEqual(out, tt.out) {
+			var b bytes.Buffer
+			b.WriteString(fmt.Sprintf("#%d: wrong output: got:\n", i))
+			for _, o := range out {
+				b.WriteString(fmt.Sprintf("%s\n", o))
+			}
+			b.WriteString(fmt.Sprintf("\nwant:\n"))
+			for _, o := range tt.out {
+				b.WriteString(fmt.Sprintf("%s\n", o))
+			}
+			t.Errorf(b.String())
 		}
 	}
 }


### PR DESCRIPTION
Hello, 
I was deploying our stolon cluster when I spotted an issue with SUReplAccessStrict mode, 
The hba generated get the master listen address instead of the standby address.
This should work as expected with this fix.