### PR TITLE
Fix FAQ link to architecture.md

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -48,7 +48,7 @@ The stolon pros are the same of the above question and it'll let you avoid the n
 
 ## What happens if etcd/consul is partitioned?
 
-See [Stolon Architecture and Requirements](doc/architecture.md)
+See [Stolon Architecture and Requirements](architecture.md)
 
 ## How are backups handled with stolon?
 


### PR DESCRIPTION
Currently links points to doc/doc/architecture.md