### PR TITLE
keeper: let postgresql manager also manage recovery.conf

### DIFF
--- a/internal/postgresql/connstring.go
+++ b/internal/postgresql/connstring.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -206,6 +207,8 @@ func URLToConnParams(urlStr string) (ConnParams, error) {
 	return p, nil
 }
 
+// ConnString returns a connection string, its entries are sorted so the
+// returned string can be reproducible and comparable
 func (p ConnParams) ConnString() string {
 	var kvs []string
 	escaper := strings.NewReplacer(` `, `\ `, `'`, `\'`, `\`, `\\`)
@@ -214,5 +217,6 @@ func (p ConnParams) ConnString() string {
 			kvs = append(kvs, k+"="+escaper.Replace(v))
 		}
 	}
+	sort.Sort(sort.StringSlice(kvs))
 	return strings.Join(kvs, " ")
 }


### PR DESCRIPTION
* Let the postgresql manager create the recovery.conf on start/restart/reload
* Define recovery.conf parameter using the SetRecoveryParameter method and
retrieve them with the RecoveryParameter method
* Simplify the logic to detect when the standby db needs to be restarted due
to changed recovery parameters since we can just compare the current and the
wanted ones.