### PR TITLE
*: set recovery_target_action to promote when using recovery target settings

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -396,10 +396,10 @@ func (p *PostgresKeeper) createRecoveryParameters(standbySettings *cluster.Stand
 		if recoveryTargetSettings.RecoveryTargetXid != "" {
 			parameters["recovery_target_xid"] = recoveryTargetSettings.RecoveryTargetXid
 		}
-
 		if recoveryTargetSettings.RecoveryTargetTimeline != "" {
 			parameters["recovery_target_timeline"] = recoveryTargetSettings.RecoveryTargetTimeline
 		}
+		parameters["recovery_target_action"] = "promote"
 	}
 
 	return parameters

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -461,6 +461,9 @@ func (os *ClusterSpec) Validate() error {
 		if s.PITRConfig.DataRestoreCommand == "" {
 			return fmt.Errorf("pitrConfig.DataRestoreCommand undefined")
 		}
+		if s.PITRConfig.RecoveryTargetSettings != nil && *s.Role == ClusterRoleStandby {
+			return fmt.Errorf("cannot define pitrConfig.RecoveryTargetSettings when required cluster role is standby")
+		}
 	default:
 		return fmt.Errorf("unknown initMode: %q", *s.InitMode)
 

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -33,6 +33,16 @@ import (
 func TestPITR(t *testing.T) {
 	t.Parallel()
 
+	testPITR(t, false)
+}
+
+func TestPITRRecoveryTarget(t *testing.T) {
+	t.Parallel()
+
+	testPITR(t, true)
+}
+
+func testPITR(t *testing.T, recoveryTarget bool) {
 	dir, err := ioutil.TempDir("", "stolon")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -109,6 +119,9 @@ func TestPITR(t *testing.T) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 
+	// save current time used to define recovery_target_time
+	now := time.Now()
+
 	// ioutil.Tempfile already creates files with 0600 permissions
 	pgpass, err := ioutil.TempFile("", "pgpass")
 	if err != nil {
@@ -155,6 +168,13 @@ func TestPITR(t *testing.T) {
 			"max_prepared_transactions": "100",
 		}),
 	}
+
+	if recoveryTarget {
+		initialClusterSpec.PITRConfig.RecoveryTargetSettings = &cluster.RecoveryTargetSettings{
+			RecoveryTargetTime: now.Format(time.RFC3339),
+		}
+	}
+
 	initialClusterSpecFile, err = writeClusterSpec(dir, initialClusterSpec)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)


### PR DESCRIPTION
* Set recovery_target_action to "promote" when using recovery target settings

* When the user specifies some recovery target settings then accept them only
when the cluster role is not standby (it doesn't makes sense to restore a
standby cluster to a different timeline or stopping at a specified time/lsn/xid)