### PR TITLE
keeper: remove trailing new lines from passwords

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -165,7 +165,7 @@ func readPasswordFromFile(filepath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to read password from file %s: %v", filepath, err)
 	}
-	return strings.TrimSpace(string(pwBytes)), nil
+	return string(pwBytes), nil
 }
 
 // walLevel returns the wal_level value to use.
@@ -1798,16 +1798,6 @@ func keeper(c *cobra.Command, args []string) {
 		log.Fatalf("only one of --pg-su-password or --pg-su-passwordfile must be provided")
 	}
 
-	if cfg.pgSUUsername == cfg.pgReplUsername {
-		log.Warn("superuser name and replication user name are the same. Different users are suggested.")
-		if cfg.pgReplAuthMethod != cfg.pgSUAuthMethod {
-			log.Fatalf("do not support different auth methods when utilizing superuser for replication.")
-		}
-		if cfg.pgSUPassword != cfg.pgReplPassword && cfg.pgSUAuthMethod != "trust" && cfg.pgReplAuthMethod != "trust" {
-			log.Fatalf("provided superuser name and replication user name are the same but provided passwords are different")
-		}
-	}
-
 	if cfg.pgReplPasswordFile != "" {
 		cfg.pgReplPassword, err = readPasswordFromFile(cfg.pgReplPasswordFile)
 		if err != nil {
@@ -1818,6 +1808,35 @@ func keeper(c *cobra.Command, args []string) {
 		cfg.pgSUPassword, err = readPasswordFromFile(cfg.pgSUPasswordFile)
 		if err != nil {
 			log.Fatalf("cannot read pg superuser password: %v", err)
+		}
+	}
+
+	// Trim trailing new lines from passwords
+	tp := strings.TrimRight(cfg.pgSUPassword, "\r\n")
+	if cfg.pgSUPassword != tp {
+		log.Warn("superuser password contain trailing new line, removing")
+		if tp == "" {
+			log.Fatalf("superuser password is empty after removing trailing new line")
+		}
+		cfg.pgSUPassword = tp
+	}
+
+	tp = strings.TrimRight(cfg.pgReplPassword, "\r\n")
+	if cfg.pgReplPassword != tp {
+		log.Warn("replication user password contain trailing new line, removing")
+		if tp == "" {
+			log.Fatalf("replication user password is empty after removing trailing new line")
+		}
+		cfg.pgReplPassword = tp
+	}
+
+	if cfg.pgSUUsername == cfg.pgReplUsername {
+		log.Warn("superuser name and replication user name are the same. Different users are suggested.")
+		if cfg.pgReplAuthMethod != cfg.pgSUAuthMethod {
+			log.Fatalf("do not support different auth methods when utilizing superuser for replication.")
+		}
+		if cfg.pgSUPassword != cfg.pgReplPassword && cfg.pgSUAuthMethod != "trust" && cfg.pgReplAuthMethod != "trust" {
+			log.Fatalf("provided superuser name and replication user name are the same but provided passwords are different")
 		}
 	}
 

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -512,3 +512,90 @@ func TestExclusiveLock(t *testing.T) {
 		t.Fatalf("expecting keeper reporting that failed to take an exclusive lock on data dir")
 	}
 }
+
+func TestPasswordTrailingNewLine(t *testing.T) {
+	t.Parallel()
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	tstore, err := NewTestStore(t, dir)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tstore.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tstore.WaitUp(10 * time.Second); err != nil {
+		t.Fatalf("error waiting on store up: %v", err)
+	}
+	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
+	defer tstore.Stop()
+
+	clusterName := uuid.NewV4().String()
+
+	u := uuid.NewV4()
+	id := fmt.Sprintf("%x", u[:4])
+
+	pgSUPassword := "stolon_superuserpassword\n"
+	pgReplPassword := "stolon_replpassword\n"
+
+	tk, err := NewTestKeeperWithID(t, dir, id, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.StartExpect(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.cmd.ExpectTimeout("superuser password contain trailing new line, removing", 30*time.Second); err != nil {
+		t.Fatalf(`expecting keeper reporting "superuser password contain trailing new line, removing"`)
+	}
+	if err := tk.cmd.ExpectTimeout("replication user password contain trailing new line, removing", 30*time.Second); err != nil {
+		t.Fatalf(`expecting keeper reporting "replication user password contain trailing new line, removing"`)
+	}
+	tk.Stop()
+
+	pgSUPassword = "stolon_superuserpassword\n"
+	pgReplPassword = "\n"
+
+	tk, err = NewTestKeeperWithID(t, dir, id, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.StartExpect(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.cmd.ExpectTimeout("replication user password contain trailing new line, removing", 30*time.Second); err != nil {
+		t.Fatalf(`expecting keeper reporting "replication user password contain trailing new line, removing"`)
+	}
+	if err := tk.cmd.ExpectTimeout("replication user password is empty after removing trailing new line", 30*time.Second); err != nil {
+		t.Fatalf(`expecting keeper reporting "replication user password is empty after removing trailing new line"`)
+	}
+
+	tk.Stop()
+
+	pgSUPassword = "\n"
+	pgReplPassword = "stolon_replpassword\n"
+
+	tk, err = NewTestKeeperWithID(t, dir, id, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.StartExpect(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.cmd.ExpectTimeout("superuser password contain trailing new line, removing", 30*time.Second); err != nil {
+		t.Fatalf(`expecting keeper reporting "superuser password contain trailing new line, removing"`)
+	}
+	if err := tk.cmd.ExpectTimeout("superuser password is empty after removing trailing new line", 30*time.Second); err != nil {
+		t.Fatalf(`expecting keeper reporting "superuser password is empty after removing trailing new line"`)
+	}
+
+	tk.Stop()
+}


### PR DESCRIPTION
Remove trailing new lines (trailing line feed and carriage return chars) like
already done by initdb and libpq when reading a password file.