### PR TITLE
*: update go version to go1.11 and simplify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@ Session.vim
 
 #
 bin/
-/gopath/
 /release/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: go
 
 go:
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
+
+go_import_path: github.com/sorintlab/stolon
 
 env:
   - TARGET=amd64

--- a/build
+++ b/build
@@ -33,18 +33,7 @@ fi
 ORG_PATH="github.com/sorintlab"
 REPO_PATH="${ORG_PATH}/stolon"
 
-# Hack to be sure that:
-# * all the dependencies are vendored
-# * if cloned as another repo name it will compile anyway
-export GOPATH=${PWD}/gopath
-
-rm -f $GOPATH/src/${REPO_PATH}
-mkdir -p $GOPATH/src/${ORG_PATH}
-ln -s ${PWD} $GOPATH/src/${REPO_PATH}
-
 mkdir -p ${BINDIR}
-
-export GO15VENDOREXPERIMENT=1
 
 VERSION=${STOLON_VERSION:-$(${BASEDIR}/scripts/git-version.sh)}
 LD_FLAGS="-s -X ${REPO_PATH}/cmd.Version=$VERSION"
@@ -72,32 +61,12 @@ if [ -w ${go_root_dir}/pkg ]; then
 	use_go_install=1
 fi
 
-if [ -z $use_go_install ]; then
-	echo "Cannot find/create a go stdlib created with cgo disabled for the go release installed at ${go_root_dir} since ${go_root_dir}/pkg is not writable by `whoami`"
-	echo "The build will use \"go build\" instead of \"go install\". This is slower since every run will need to rebuild all the needed packages."
-	echo "To speed up the build you should make ${go_root_dir}/pkg writable for `whoami` for at least the first build"
-	echo "or manually rebuild stdlib executing the command 'CGO_ENABLED=0 go install -a -installsuffix cgo std' from a user with write access to ${go_root_dir}/pkg"
+for cmd in sentinel proxy; do
+	CGO_ENABLED=0 go build -installsuffix cgo -ldflags "$LD_FLAGS" -o ${BINDIR}/stolon-${cmd} ${REPO_PATH}/cmd/${cmd}
+done
+CGO_ENABLED=0 go build -installsuffix cgo -ldflags "$LD_FLAGS" -o ${BINDIR}/stolonctl ${REPO_PATH}/cmd/stolonctl
 
-	for cmd in sentinel proxy; do
-		CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "$LD_FLAGS" -o ${BINDIR}/stolon-${cmd} ${REPO_PATH}/cmd/${cmd}
-	done
-	CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "$LD_FLAGS" -o ${BINDIR}/stolonctl ${REPO_PATH}/cmd/stolonctl
-else
-	for cmd in sentinel proxy; do
-		CGO_ENABLED=0 go install -installsuffix cgo -ldflags "$LD_FLAGS" ${REPO_PATH}/cmd/${cmd}
-		rm -f ${BINDIR}/stolon-${cmd}
-		cp ${GOPATH}/bin/${cmd} ${BINDIR}/stolon-${cmd}
-	done
-	CGO_ENABLED=0 go install -installsuffix cgo -ldflags "$LD_FLAGS" ${REPO_PATH}/cmd/stolonctl
-	rm -f ${BINDIR}/stolonctl
-	cp ${GOPATH}/bin/stolonctl ${BINDIR}/
-fi
-
-# stolon-keeper cannot be statically built since it needs to get its current
-# running user and this is not available with cgo disabled
-go install -ldflags "$LD_FLAGS" ${REPO_PATH}/cmd/keeper
-rm -f ${BINDIR}/stolon-keeper
-cp ${GOPATH}/bin/keeper ${BINDIR}/stolon-keeper
+go build -ldflags "$LD_FLAGS" -o ${BINDIR}/stolon-keeper ${REPO_PATH}/cmd/keeper 
 
 # Copy binaries to Dockerfile image directories
 declare -a DOCKERFILE_PATHS

--- a/scripts/semaphore-k8s.sh
+++ b/scripts/semaphore-k8s.sh
@@ -27,8 +27,11 @@ touch $HOME/.kube/config
 export KUBECONFIG=$HOME/.kube/config
 sudo -E minikube start --vm-driver=none
 
-# Precompile stdlib with cgo disable to speedup builds
-sudo -E CGO_ENABLED=0 go install -a -installsuffix cgo std
+# Fix build to work with the right import path also when building github forked repositories
+if [[ ! -e ~/workspace/src/github.com/sorintlab/stolon ]]; then
+  mkdir -p ~/workspace/src/github.com/sorintlab
+  ln -s /home/runner/stolon ~/workspace/src/github.com/sorintlab/stolon
+fi
 
 ./build
 

--- a/scripts/semaphore.sh
+++ b/scripts/semaphore.sh
@@ -31,8 +31,11 @@ wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-
 sudo apt-get update
 sudo apt-get -y install postgresql-9.5 postgresql-9.6 postgresql-10 postgresql-11
 
-# Precompile stdlib with cgo disable to speedup builds
-sudo -E CGO_ENABLED=0 go install -a -installsuffix cgo std
+# Fix build to work with the right import path also when building github forked repositories
+if [[ ! -e ~/workspace/src/github.com/sorintlab/stolon ]]; then
+  mkdir -p ~/workspace/src/github.com/sorintlab
+  ln -s /home/runner/stolon ~/workspace/src/github.com/sorintlab/stolon
+fi
 
 # Run tests
 export ETCD_BIN="${PWD}/etcd/etcd-v3.2.11-linux-amd64/etcd"

--- a/test
+++ b/test
@@ -23,11 +23,6 @@ REPO_PATH="${ORG_PATH}/stolon"
 
 ./build
 
-# Hack to be sure that:
-# * all the dependencies are vendored
-# * if cloned as another repo name it will compile anyway
-export GOPATH=${PWD}/gopath
-
 # test all packages excluding integration tests
 IGNORE_PKGS="(vendor/|tests/integration)"
 PACKAGES=$(find . -name \*_test.go | while read -r a; do dirname "$a"; done | sort | uniq | grep -vE "$IGNORE_PKGS" | sed "s|\./||g")


### PR DESCRIPTION
* use go 1.10.x and 1.11.x on travis
* Remove the build hack that uses a local GOPATH:
  * Use `go_import_path` on travis and create a symlink to the main org repo on
  semaphore
  * Users forking stolon repo on github should just use git remotes in the main
  repo clone
* Remove messages to build a cgo enabled stdlib, go build cache introduced in go
1.10 also caches this.
* Always use `go build` instead of `go install` so we can directly place
binaries in the project bin dir and choose the binary name