### PR TITLE
Use readlinkdashf function in test for cross compatibility with osx

### DIFF
--- a/test
+++ b/test
@@ -11,7 +11,28 @@
 #
 set -e
 
-BASEDIR=$(readlink -f $(dirname $0))
+# Cross compatibility with osx
+# origin source: https://github.com/kubernetes/kubernetes/blob/master/hack/lib/init.sh#L102
+function readlinkdashf() {
+	# run in a subshell for simpler 'cd'
+  (
+    if [[ -d "$1" ]]; then # This also catch symlinks to dirs.
+      cd "$1"
+      pwd -P
+    else
+      cd $(dirname "$1")
+      local f
+      f=$(basename "$1")
+      if [[ -L "$f" ]]; then
+        readlink "$f"
+      else
+        echo "$(pwd -P)/${f}"
+      fi
+    fi
+  )
+}
+
+BASEDIR=$(readlinkdashf $(dirname $0))
 BINDIR=${BASEDIR}/bin
 
 if [ $PWD != $BASEDIR ]; then


### PR DESCRIPTION
readlink -f option is not available in osx,
instead use greadlink package which is GNU readlink for osx if available
Homebrew provide a coreutils package containing greadlink (GNU readlink)