### PR TITLE
[WIP] Add command to restart all underlying pg

### DIFF
--- a/cmd/stolonctl/cmd/pgrestart.go
+++ b/cmd/stolonctl/cmd/pgrestart.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+
+	cmdcommon "github.com/sorintlab/stolon/cmd"
+	"github.com/sorintlab/stolon/internal/cluster"
+	slog "github.com/sorintlab/stolon/internal/log"
+	"github.com/sorintlab/stolon/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var log = slog.S()
+
+var pgRestartCmd = &cobra.Command{
+	Use:   "pgrestart",
+	Short: `Restarts the underlying postgres cluster with minimal downtime`,
+	Long:  `Restarts the underlying postgres cluster with minimal downtime`,
+	Run:   pgRestart,
+}
+
+func init() {
+	CmdStolonCtl.AddCommand(pgRestartCmd)
+}
+
+func pgRestart(cmd *cobra.Command, args []string) {
+	store, err := cmdcommon.NewStore(&cfg.CommonConfig)
+	if err != nil {
+		die("%v", err)
+	}
+
+	cd, pair := fatalGetClusterData(store)
+
+	newCd := cd.DeepCopy()
+
+	log.Infow("Restarting all postgres instances!")
+	for _, db := range newCd.DBs {
+		k, ok := newCd.Keepers[db.Spec.KeeperUID]
+
+		if !ok {
+			die("Keeper data was empty for the DB")
+		}
+
+		k.Status.Healthy = false
+		k.Status.SchedulePgRestart = true
+	}
+
+	_, err = store.AtomicPutClusterData(context.TODO(), newCd, pair)
+	if err != nil {
+		die("cannot update cluster data: %v", err)
+	}
+}
+
+func fatalGetClusterData(e store.Store) (*cluster.ClusterData, *store.KVPair) {
+	cd, pair, err := getClusterData(e)
+	if err != nil {
+		die("cannot get cluster data: %v", err)
+	}
+	if cd.Cluster == nil {
+		die("no cluster spec available")
+	}
+	if cd.Cluster.Spec == nil {
+		die("no cluster spec available")
+	}
+
+	return cd, pair
+}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -546,6 +546,8 @@ type KeeperStatus struct {
 	PostgresBinaryVersion PostgresBinaryVersion `json:"postgresBinaryVersion,omitempty"`
 
 	ForceFail bool `json:"forceFail,omitempty"`
+
+	SchedulePgRestart bool `json:"schedulePgRestart,omitempty"`
 }
 
 type Keeper struct {


### PR DESCRIPTION
Fixes #88 

This PR is to restart the underlying postgres instances of all keepers

## Reason

Few parameters like `max_connections` and `shared_buffers` require restart of underlying postgres in each Keeper. We always had to run a `pg_ctl stop -m fast -W` on the node/pod to restart the postgres (keeper only does a reload)

## Approach

*Keeper*

- Stolon Keepers watch for a flag in ClusterData.Keeper.Status if `schedulePgRestart` is set to true
- If true, a keeper would set it false and restart the underlying postgres using `pgManager`

*CLI*

- `stolonctl` has a subcommand called `pgrestart`
- It would set `schedulePgRestart` to `true` for all keepers (which would trigger a restart of all clusters)

## Objective

Initially, we wanted to achieve a restart with 0 downtime by promoting an existing slave as a master as present in #88 However, it takes 7 seconds to elect a new master. Simply triggering a fast restart of postgres only cause 1 second downtime.

Please share your comments and feedbacks.