### PR TITLE
Make readlink work in osx for gen_commands_doc.sh

### DIFF
--- a/build
+++ b/build
@@ -1,27 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-
-# Cross compatibility with osx
-# origin source: https://github.com/kubernetes/kubernetes/blob/master/hack/lib/init.sh#L102
-function readlinkdashf() {
-	# run in a subshell for simpler 'cd'
-  (
-    if [[ -d "$1" ]]; then # This also catch symlinks to dirs.
-      cd "$1"
-      pwd -P
-    else
-      cd $(dirname "$1")
-      local f
-      f=$(basename "$1")
-      if [[ -L "$f" ]]; then
-        readlink "$f"
-      else
-        echo "$(pwd -P)/${f}"
-      fi
-    fi
-  )
-}
+source scripts/readlinkdashf.sh
 
 BASEDIR=$(readlinkdashf $(dirname $0))
 BINDIR=${BASEDIR}/bin

--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-source scripts/readlinkdashf.sh
+source $(dirname $0)/scripts/readlinkdashf.sh
 
 BASEDIR=$(readlinkdashf $(dirname $0))
 BINDIR=${BASEDIR}/bin

--- a/scripts/gen_commands_doc.sh
+++ b/scripts/gen_commands_doc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-source readlinkdashf.sh
+source $(dirname $0)/readlinkdashf.sh
 
 BASEDIR=$(readlinkdashf $(dirname $0)/..)
 

--- a/scripts/gen_commands_doc.sh
+++ b/scripts/gen_commands_doc.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
+source readlinkdashf.sh
 
-BASEDIR=$(readlink -f $(dirname $0)/..)
+BASEDIR=$(readlinkdashf $(dirname $0)/..)
 
 go run $BASEDIR/scripts/gen_commands_doc.go $BASEDIR/doc/commands/

--- a/scripts/readlinkdashf.sh
+++ b/scripts/readlinkdashf.sh
@@ -1,0 +1,20 @@
+# Cross compatibility with osx
+# origin source: https://github.com/kubernetes/kubernetes/ blob/master/hack/lib/init.sh#L102
+function readlinkdashf() {
+  # run in a subshell for simpler 'cd'
+  (
+    if [[ -d "$1" ]]; then # This also catch symlinks to   dirs.
+      cd "$1"
+      pwd -P
+    else
+      cd $(dirname "$1")
+      local f
+      f=$(basename "$1")
+      if [[ -L "$f" ]]; then
+        readlink "$f"
+      else
+        echo "$(pwd -P)/${f}"
+      fi
+    fi
+  )
+}

--- a/test
+++ b/test
@@ -11,7 +11,7 @@
 #
 set -e
 
-source scripts/readlinkdashf.sh
+source $(dirname $0)/scripts/readlinkdashf.sh
 BASEDIR=$(readlinkdashf $(dirname $0))
 BINDIR=${BASEDIR}/bin
 

--- a/test
+++ b/test
@@ -11,27 +11,7 @@
 #
 set -e
 
-# Cross compatibility with osx
-# origin source: https://github.com/kubernetes/kubernetes/blob/master/hack/lib/init.sh#L102
-function readlinkdashf() {
-	# run in a subshell for simpler 'cd'
-  (
-    if [[ -d "$1" ]]; then # This also catch symlinks to dirs.
-      cd "$1"
-      pwd -P
-    else
-      cd $(dirname "$1")
-      local f
-      f=$(basename "$1")
-      if [[ -L "$f" ]]; then
-        readlink "$f"
-      else
-        echo "$(pwd -P)/${f}"
-      fi
-    fi
-  )
-}
-
+source scripts/readlinkdashf.sh
 BASEDIR=$(readlinkdashf $(dirname $0))
 BINDIR=${BASEDIR}/bin
 


### PR DESCRIPTION
Tasks:
1. Moved `readlinkdashf` function in `build`, `test` to common file `readlinkdashf.sh`
2. Using `readlinkdashf.sh` file in `gen_commands_doc.sh` to generate docs in mac.