### PR TITLE
Add overwriteDB flag. This allows user to safely call init cluster

### DIFF
--- a/cmd/stolonctl/cmd/init.go
+++ b/cmd/stolonctl/cmd/init.go
@@ -35,6 +35,7 @@ var cmdInit = &cobra.Command{
 type InitOptions struct {
 	file     string
 	forceYes bool
+	overwriteDb bool
 }
 
 var initOpts InitOptions
@@ -42,6 +43,7 @@ var initOpts InitOptions
 func init() {
 	cmdInit.PersistentFlags().StringVarP(&initOpts.file, "file", "f", "", "file contaning the new cluster spec")
 	cmdInit.PersistentFlags().BoolVarP(&initOpts.forceYes, "yes", "y", false, "don't ask for confirmation")
+	cmdInit.PersistentFlags().BoolVarP(&initOpts.overwriteDb, "overwrite", "o", true, "overwrite DB even if it exists, default:yes")
 
 	CmdStolonCtl.AddCommand(cmdInit)
 }
@@ -82,6 +84,10 @@ func initCluster(cmd *cobra.Command, args []string) {
 		die("cannot get cluster data: %v", err)
 	}
 	if cd != nil {
+		if !initOpts.overwriteDb {
+			stdout("exiting as DB is already initialized")
+			os.Exit(0)
+		}
 		stdout("WARNING: The current cluster data will be removed")
 	}
 	stdout("WARNING: The databases managed by the keepers will be overwritten depending on the provided cluster spec.")


### PR DESCRIPTION
cluster without fear of overwriting an existing DB.
Usage: init -o=false
Default is true, to preserve original behavior.