### PR TITLE
postgres: use sql db context functions

### DIFF
--- a/internal/postgresql/utils.go
+++ b/internal/postgresql/utils.go
@@ -40,45 +40,11 @@ var (
 )
 
 func dbExec(ctx context.Context, db *sql.DB, query string, args ...interface{}) (sql.Result, error) {
-	ch := make(chan struct {
-		res sql.Result
-		err error
-	})
-	go func() {
-		res, err := db.Exec(query, args...)
-		ch <- struct {
-			res sql.Result
-			err error
-		}{res, err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case out := <-ch:
-		return out.res, out.err
-	}
+	return db.ExecContext(ctx, query, args...)
 }
 
 func query(ctx context.Context, db *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
-	ch := make(chan struct {
-		rows *sql.Rows
-		err  error
-	})
-	go func() {
-		rows, err := db.Query(query, args...)
-		ch <- struct {
-			rows *sql.Rows
-			err  error
-		}{rows, err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case out := <-ch:
-		return out.rows, out.err
-	}
+	return db.QueryContext(ctx, query, args...)
 }
 
 func ping(ctx context.Context, connParams ConnParams) error {


### PR DESCRIPTION
Now that golang sql.db and libpq support context in exec and query functions for
some time, use them.

Will possibly fix a connection leak when ctx expires since the current
implementation doesn't close sql rows on context expire.