### PR TITLE
Fix failover process after disk crash

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -558,7 +558,6 @@ func (p *PostgresKeeper) updatePGState(pctx context.Context) {
 	pgState, err := p.GetPGState(pctx)
 	if err != nil {
 		log.Errorw("failed to get pg state", zap.Error(err))
-		return
 	}
 	p.lastPGState = pgState
 }
@@ -641,7 +640,7 @@ func (p *PostgresKeeper) GetPGState(pctx context.Context) (*cluster.PostgresStat
 
 	initialized, err := p.pgm.IsInitialized()
 	if err != nil {
-		return nil, err
+		return pgState, err
 	}
 	if initialized {
 		pgParameters, err := p.pgm.GetConfigFilePGParameters()


### PR DESCRIPTION
I have encountered the problem on test mini installation (cluster based on raspberry pi) that autofailover didn't performed after disk (SD card, in case of raspberry) manual insulation.

The problem lies in `PostgresKeeper.updatePGState` routine (cmd/keeper/cmd/keeper.go:561) that Postgres state isn't updated in DCS (consul or etcd) when `PostgresKeeper.GetPGState` routine returns some not null error. Such error is emitted after check whether PGDATA is initialized (`Manager.IsInitialized` routine, cmd/keeper/cmd/keeper.go:641) what is induced after disk file system operation failure (my case).

The current pull request fixes this issue.