### PR TITLE
keeper Prometheus metrics

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -751,6 +751,10 @@ func (p *PostgresKeeper) Start(ctx context.Context) {
 	updatePGStateTimerCh := time.NewTimer(0).C
 	updateKeeperInfoTimerCh := time.NewTimer(0).C
 	for true {
+		// The sleepInterval can be updated during normal execution. Ensure we regularly
+		// refresh the metric to account for those changes.
+		sleepInterval.Set(float64(p.sleepInterval / time.Second))
+
 		select {
 		case <-ctx.Done():
 			log.Debugw("stopping stolon keeper")
@@ -966,6 +970,12 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 		log.Errorw("clusterdata validation failed", zap.Error(err))
 		return
 	}
+
+	// Mark that the clusterdata we've received is valid. We'll use this metric to detect
+	// when our store is failing to serve a valid clusterdata, so it's important we only
+	// update the metric here.
+	clusterdataLastValidUpdateSeconds.SetToCurrentTime()
+
 	if cd.Cluster != nil {
 		p.sleepInterval = cd.Cluster.DefSpec().SleepInterval.Duration
 		p.requestTimeout = cd.Cluster.DefSpec().RequestTimeout.Duration
@@ -1391,6 +1401,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	targetRole := db.Spec.Role
 	log.Debugw("target role", "targetRole", string(targetRole))
 
+	// Set metrics to power alerts about mismatched roles
+	setRole(localRoleGauge, &localRole)
+	setRole(targetRoleGauge, &targetRole)
+
 	switch targetRole {
 	case common.RoleMaster:
 		// We are the elected master
@@ -1594,23 +1608,31 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 	}
 
 	if needsReload {
+		needsReloadGauge.Set(1) // mark as reload needed
 		if err := pgm.Reload(); err != nil {
 			log.Errorw("failed to reload postgres instance", err)
+		} else {
+			needsReloadGauge.Set(0) // successful reload implies no longer required
 		}
+	}
 
+	{
 		clusterSpec := cd.Cluster.DefSpec()
 		automaticPgRestartEnabled := *clusterSpec.AutomaticPgRestart
 
-		if automaticPgRestartEnabled {
-			needsRestart, err := pgm.IsRestartRequired(changedParams)
-			if err != nil {
-				log.Errorw("Failed to checked if restart is required", err)
-			}
+		needsRestart, err := pgm.IsRestartRequired(changedParams)
+		if err != nil {
+			log.Errorw("Failed to checked if restart is required", err)
+		}
 
-			if needsRestart {
+		if needsRestart {
+			needsRestartGauge.Set(1) // mark as restart needed
+			if automaticPgRestartEnabled {
 				log.Infow("Restarting postgres")
 				if err := pgm.Restart(true); err != nil {
 					log.Errorw("Failed to restart postgres instance", err)
+				} else {
+					needsRestartGauge.Set(0) // successful restart implies no longer required
 				}
 			}
 		}
@@ -1624,6 +1646,10 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 		log.Errorw("failed to save db local state", zap.Error(err))
 		return
 	}
+
+	// We want to set this only if no error has occurred. We should be able to identify
+	// keeper issues by watching for this value becoming stale.
+	lastSyncSuccessSeconds.SetToCurrentTime()
 }
 
 func (p *PostgresKeeper) keeperLocalStateFilePath() string {
@@ -1770,6 +1796,7 @@ func (p *PostgresKeeper) generateHBA(cd *cluster.ClusterData, db *cluster.DB, on
 func sigHandler(sigs chan os.Signal, cancel context.CancelFunc) {
 	s := <-sigs
 	log.Debugw("got signal", "signal", s)
+	shutdownSeconds.SetToCurrentTime()
 	cancel()
 }
 
@@ -1815,6 +1842,8 @@ func keeper(c *cobra.Command, args []string) {
 	if err = cmd.CheckCommonConfig(&cfg.CommonConfig); err != nil {
 		log.Fatalf(err.Error())
 	}
+
+	cmd.SetMetrics(&cfg.CommonConfig)
 
 	if err = os.MkdirAll(cfg.dataDir, 0700); err != nil {
 		log.Fatalf("cannot create data dir: %v", err)

--- a/cmd/keeper/cmd/metrics.go
+++ b/cmd/keeper/cmd/metrics.go
@@ -1,0 +1,98 @@
+// Copyright 2017 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sorintlab/stolon/internal/common"
+)
+
+var (
+	clusterdataLastValidUpdateSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_clusterdata_last_valid_update_seconds",
+			Help: "Last time we received a valid clusterdata from our store as seconds since unix epoch",
+		},
+	)
+	targetRoleGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_target_role",
+			Help: "Keeper last requested target role",
+		},
+		[]string{"role"},
+	)
+	localRoleGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_local_role",
+			Help: "Keeper current local role",
+		},
+		[]string{"role"},
+	)
+	needsReloadGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_needs_reload",
+			Help: "Set to 1 if Postgres requires reload",
+		},
+	)
+	needsRestartGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_needs_restart",
+			Help: "Set to 1 if Postgres requires restart",
+		},
+	)
+	lastSyncSuccessSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_last_sync_success_seconds",
+			Help: "Last time we successfully synced our keeper",
+		},
+	)
+	sleepInterval = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_sleep_interval",
+			Help: "Seconds to sleep between sync loops",
+		},
+	)
+	shutdownSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "stolon_keeper_shutdown_seconds",
+			Help: "Shutdown time (received termination signal) since unix epoch in seconds",
+		},
+	)
+)
+
+// setRole is a helper that controls the targetRole metric by setting only one of the
+// possible roles to 1 at any one time.
+func setRole(rg *prometheus.GaugeVec, role *common.Role) {
+	for _, role := range common.Roles {
+		rg.WithLabelValues(string(role)).Set(0)
+	}
+
+	if role != nil {
+		rg.WithLabelValues(string(*role)).Set(1)
+	}
+}
+
+func init() {
+	prometheus.MustRegister(clusterdataLastValidUpdateSeconds)
+	prometheus.MustRegister(targetRoleGauge)
+	setRole(targetRoleGauge, nil)
+	prometheus.MustRegister(localRoleGauge)
+	setRole(localRoleGauge, nil)
+	prometheus.MustRegister(needsReloadGauge)
+	prometheus.MustRegister(needsRestartGauge)
+	prometheus.MustRegister(lastSyncSuccessSeconds)
+	prometheus.MustRegister(sleepInterval)
+	prometheus.MustRegister(shutdownSeconds)
+}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -42,6 +42,13 @@ const (
 	RoleStandby   Role = "standby"
 )
 
+// Roles enumerates all possible Role values
+var Roles = []Role{
+	RoleUndefined,
+	RoleMaster,
+	RoleStandby,
+}
+
 func UID() string {
 	u := uuid.NewV4()
 	return fmt.Sprintf("%x", u[:4])


### PR DESCRIPTION
Add a collection of Prometheus metrics to the keeper. The metrics are
aimed to expose errors in the keeper sync loop, providing enough
visibility to detect when the sync is failing (and some insight into
why).

---

Hey stolon maintainers! I want to make this as easy as possible to review, so I'm going to try and write everything you need up-front here. If you have any questions just drop a comment and I'll do my best to answer them.

We're currently moving our Postgres cluster to use stolon, and in doing so we've adapted some tooling we already had to enable zero-downtime planned failover. The tool that allows this is called [stolon-pgbouncer](https://github.com/gocardless/stolon-pgbouncer) which explains its purpose and aims in the readme.

stolon-pgbouncer has native Prometheus metrics and bundles with it some Prometheus alerts and dashboards. If you clone this repo and run `docker-compose up`, then navigate to http://localhost:3000 (login as admin/admin, skip password) you'll see two dashboards, one for the stolon-pgbouncer services and another for stolon-keepers.

The master branch of stolon-pgbouncer will boot with a compiled stolon-keeper binary from this PR. This enables us to scrape and display the stolon-keeper metrics in a dashboard we bundle with stolon-pgbouncer (PR that introduces this is [here](https://github.com/gocardless/stolon-pgbouncer/pull/29)) which looks like this:

![image](https://user-images.githubusercontent.com/3518874/57087638-685b1680-6cf8-11e9-9321-846f065dc01d.png)

It's meant to be a one-stop-shop for keeper state, while the [alerts](https://github.com/gocardless/stolon-pgbouncer/blob/master/docker/observability/prometheus/rules.yml#L146-L179) we've defined on these metrics aim to capture whenever keepers are misbehaving or Postgres is pending a restart.

We'd love to get these metrics upstreamed to benefit all stolon users, as well as obviously making our lives easier by avoiding maintaining a fork!