### PR TITLE
Add option to configure max-rate for pg_basebackup

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1014,6 +1014,7 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 
 	// Generate hba auth from clusterData
 	pgm.SetHba(p.generateHBA(cd, db, p.waitSyncStandbysSynced))
+	pgm.SetPGBasebackupMaxRate(cd.Cluster.Spec.PGBasebackupMaxRate)
 
 	var pgParameters common.Parameters
 

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -65,3 +65,41 @@ func TestValidateReplicationSlots(t *testing.T) {
 		}
 	}
 }
+
+func TestClusterSpec_Validate(t *testing.T) {
+	t.Run("should validate PGBasebackupMaxRate", func(t *testing.T) {
+		var initMode = ClusterInitMode("new")
+		var spec *ClusterSpec
+
+		tests := []struct {
+			rate        string
+			shouldError bool
+		}{
+			{"10", true},
+			{"10k", true},
+			{"32k", false},
+			{"10M", false},
+			{"1024M", false},
+			{"1023M", false},
+			{"1025M", true},
+			{"fM", true},
+			{"", false},
+		}
+		for i, tt := range tests {
+			spec = &ClusterSpec{
+				InitMode:            &initMode,
+				PGBasebackupMaxRate: tt.rate,
+			}
+
+			err := spec.Validate()
+
+			if tt.shouldError && (err == nil) {
+				t.Errorf("#%d: expected error for max-rate: %s, actual no error", i, tt.rate)
+			}
+
+			if !tt.shouldError && (err != nil) {
+				t.Errorf("#%d: unexpected error for max-rate: %s, error: %v", i, tt.rate, err)
+			}
+		}
+	})
+}

--- a/internal/common/bytesize.go
+++ b/internal/common/bytesize.go
@@ -1,0 +1,58 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// Bytesize is useful to represent bytes and perform operations on it
+type Bytesize int
+
+// Common bytesizes than can be used
+const (
+	Byte     Bytesize = 1
+	Kilobyte          = 1024 * Byte
+	Megabyte          = 1024 * Kilobyte
+)
+
+const pattern = `([0-9]+)(k|M)`
+
+// ParseBytesize allows to parse the given input into Bytesize
+// Allowed formats is [:digit:] suffixed by k (kilobyte) or M (Megabyte)
+func ParseBytesize(input string) (Bytesize, error) {
+	re := regexp.MustCompile(pattern)
+	allMatches := re.FindStringSubmatch(input)
+	if len(allMatches) != 3 {
+		return 0, fmt.Errorf("unable to parse %s: must be of the format %s", input, pattern)
+	}
+
+	size, err := strconv.Atoi(allMatches[1])
+	if err != nil {
+		return 0, fmt.Errorf("unable to parse as integer %s: %v", allMatches[1], err)
+	}
+
+	unit := allMatches[2]
+	switch unit {
+	case "k":
+		return Bytesize(size) * Kilobyte, nil
+	case "M":
+		return Bytesize(size) * Megabyte, nil
+	default:
+		return 0, fmt.Errorf("%s can either be suffixed with k or M", allMatches[2])
+	}
+}

--- a/internal/common/bytesize_test.go
+++ b/internal/common/bytesize_test.go
@@ -1,0 +1,48 @@
+// Copyright 2016 Sorint.lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import "testing"
+
+func TestParseBytesize(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    Bytesize
+		shouldError bool
+	}{
+		{"10", 0, true},
+		{"10k", 10 * Kilobyte, false},
+		{"32k", 32 * Kilobyte, false},
+		{"10M", 10 * Megabyte, false},
+		{"fM", 0, true},
+		{"", 0, true},
+	}
+
+	for i, tt := range tests {
+		actual, err := ParseBytesize(tt.input)
+
+		if tt.shouldError && (err == nil) {
+			t.Errorf("#%d: expected error for: %s, actual no error", i, tt.input)
+		}
+
+		if !tt.shouldError && (err != nil) {
+			t.Errorf("#%d: unexpected error for: %s, error: %v", i, tt.input, err)
+		}
+
+		if actual != tt.expected {
+			t.Errorf("#%d: unexpected value. got: %d, expected: %d", i, actual, tt.expected)
+		}
+	}
+}

--- a/internal/postgresql/postgresql.go
+++ b/internal/postgresql/postgresql.go
@@ -71,6 +71,7 @@ type Manager struct {
 	replUsername          string
 	replPassword          string
 	requestTimeout        time.Duration
+	pgBasebackupMaxRate   string
 }
 
 type SystemData struct {
@@ -137,6 +138,11 @@ func (p *Manager) SetHba(hba []string) {
 
 func (p *Manager) CurHba() []string {
 	return p.curHba
+}
+
+// SetPGBasebackupMaxRate is a setter for pgBasebackupMaxRate
+func (p *Manager) SetPGBasebackupMaxRate(rate string) {
+	p.pgBasebackupMaxRate = rate
 }
 
 func (p *Manager) UpdateCurParameters() {
@@ -826,6 +832,9 @@ func (p *Manager) SyncFromFollowed(followedConnParams ConnParams, replSlot strin
 	args := []string{"-R", "-Xs", "-D", p.dataDir, "-d", followedConnString}
 	if replSlot != "" {
 		args = append(args, "--slot", replSlot)
+	}
+	if p.pgBasebackupMaxRate != "" {
+		args = append(args, "--max-rate", p.pgBasebackupMaxRate)
 	}
 	cmd := exec.Command(name, args...)
 


### PR DESCRIPTION
Fixes #649 

## Changelog:
1. Allows configuring `--max-rate` when running `pg_basebackup` through a cluster spec variable `"pgBasebackupMaxRate"`

This is useful to reduce the load on master server when running `pg_basebackup`

Will add integration tests if you are okay with this feature and if the contents of the PR is okay.

