### PR TITLE
Limit to fetching last N timeline history

### DIFF
--- a/internal/postgresql/utils.go
+++ b/internal/postgresql/utils.go
@@ -33,6 +33,8 @@ import (
 const (
 	// TODO(sgotti) for now we assume wal size is the default 16MiB size
 	WalSegSize = (16 * 1024 * 1024) // 16MiB
+	// TimelineHistoryLimit is the number of timehistory maintained in clusterdata
+	TimelineHistoryLimit = 1000
 )
 
 var (
@@ -270,6 +272,9 @@ func parseTimelinesHistory(contents string) ([]*TimelineHistory, error) {
 			tlh.Reason = m[3]
 			tlsh = append(tlsh, &tlh)
 		}
+	}
+	if len(tlsh) > TimelineHistoryLimit {
+		return tlsh[len(tlsh)-TimelineHistoryLimit:], nil
 	}
 	return tlsh, err
 }


### PR DESCRIPTION
Fixes #629 

Changelog:
1. Fetch only last 1000 entries in timeline history after parsing contents

Questions:
1. Is this implementation correct?
2. The file is read and parsed inspite of the limit. Shall I optimize reading the file so that only last N lines are parsed?
3. The limit is set as 1000 (a const). Should it be made configurable or changed to a different value?