### PR TITLE
Small dead code removal in Sentinel.go

### DIFF
--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -327,7 +327,6 @@ func (s *Sentinel) updateKeepersStatus(cd *cluster.ClusterData, keepersInfo clus
 func (s *Sentinel) activeProxiesInfos(proxiesInfo cluster.ProxiesInfo) cluster.ProxiesInfo {
 	pihs := s.proxyInfoHistories.DeepCopy()
 
-	tmpPihs := pihs.DeepCopy()
 	// remove missing proxyInfos from the history
 	for proxyUID, _ := range pihs {
 		if _, ok := proxiesInfo[proxyUID]; !ok {
@@ -335,7 +334,6 @@ func (s *Sentinel) activeProxiesInfos(proxiesInfo cluster.ProxiesInfo) cluster.P
 		}
 
 	}
-	pihs = tmpPihs
 
 	activeProxiesInfo := proxiesInfo.DeepCopy()
 	// keep only updated proxies info

--- a/cmd/sentinel/cmd/sentinel_test.go
+++ b/cmd/sentinel/cmd/sentinel_test.go
@@ -5039,6 +5039,13 @@ func TestActiveProxiesInfos(t *testing.T) {
 			expectedActiveProxies:      cluster.ProxiesInfo{"proxy2": &proxyInfo2},
 			expectedProxyInfoHistories: ProxyInfoHistories{"proxy1": &ProxyInfoHistory{ProxyInfo: &proxyInfo1}, "proxy2": &ProxyInfoHistory{ProxyInfo: &proxyInfo2}},
 		},
+		{
+			name:                       "should remove proxy from sentinel's local history if the proxy is removed in store",
+			proxyInfoHistories:         ProxyInfoHistories{"proxy1": &ProxyInfoHistory{ProxyInfo: &proxyInfo1, Timer: timer.Now()}, "proxy2": &ProxyInfoHistory{ProxyInfo: &proxyInfo2, Timer: timer.Now()}},
+			proxiesInfos:               cluster.ProxiesInfo{"proxy2": &proxyInfo2},
+			expectedActiveProxies:      cluster.ProxiesInfo{"proxy2": &proxyInfo2},
+			expectedProxyInfoHistories: ProxyInfoHistories{"proxy2": &ProxyInfoHistory{ProxyInfo: &proxyInfo2}},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Hi @sgotti,
I was going through the code base to better understand the stolon. I came across `one dead code` in **Sentinel.go**. 

To verify that 
- First, I wrote unit tests for that method (first commit in this PR)
- Second, I removed that dead code and checked. All the tests are passing (second commit)

Please lemme know if I missed any test cases.