### PR TITLE
Allow special characters in pg-su-username

### DIFF
--- a/internal/postgresql/utils.go
+++ b/internal/postgresql/utils.go
@@ -68,7 +68,7 @@ func setPassword(ctx context.Context, connParams ConnParams, username, password 
 	}
 	defer db.Close()
 
-	_, err = dbExec(ctx, db, fmt.Sprintf(`alter role %s with password '%s';`, username, password))
+	_, err = dbExec(ctx, db, fmt.Sprintf(`alter role "%s" with password '%s';`, username, password))
 	return err
 }
 


### PR DESCRIPTION
If we are having special characters in su username like below
```bash
./stolon-keeper --pg-su-username=user-name # other flags
```
We are getting below error
```
INFO    postgresql/postgresql.go:534    setting superuser password
2019-06-01 01:34:40.031 IST [60923] ERROR:  syntax error at or near "-" at character 14
```

But in postgres, having role as `user-name` is allowed. So it is better if stolon also allow this.

I just added double quotes for `username` in `alter role` command.

> There are two more places in `stolon` where we are altering role. In those two places we are already using double quotes. https://github.com/sorintlab/stolon/blob/master/internal/postgresql/utils.go#L104 and https://github.com/sorintlab/stolon/blob/master/internal/postgresql/utils.go#L115