### PR TITLE
keeper: fix some logging

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1633,15 +1633,15 @@ func (p *PostgresKeeper) postgresKeeperSM(pctx context.Context) {
 
 		needsRestart, err := pgm.IsRestartRequired(changedParams)
 		if err != nil {
-			log.Errorw("Failed to checked if restart is required", err)
+			log.Errorw("failed to check if restart is required", zap.Error(err))
 		}
 
 		if needsRestart {
 			needsRestartGauge.Set(1) // mark as restart needed
 			if automaticPgRestartEnabled {
-				log.Infow("Restarting postgres")
+				log.Infow("restarting postgres")
 				if err := pgm.Restart(true); err != nil {
-					log.Errorw("Failed to restart postgres instance", err)
+					log.Errorw("failed to restart postgres instance", zap.Error(err))
 				} else {
 					needsRestartGauge.Set(0) // successful restart implies no longer required
 				}

--- a/internal/postgresql/postgresql.go
+++ b/internal/postgresql/postgresql.go
@@ -935,7 +935,7 @@ func (p *Manager) OlderWalFile() (string, error) {
 func (p *Manager) IsRestartRequired(changedParams []string) (bool, error) {
 	maj, min, err := p.BinaryVersion()
 	if err != nil {
-		return false, fmt.Errorf("Error fetching pg version for checking IsRestartRequired, %v", err)
+		return false, fmt.Errorf("error fetching pg version: %v", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), p.requestTimeout)


### PR DESCRIPTION
Remove capital first letter and use zap.Error to wrap errors