### PR TITLE
keeper: configurable wal_keep_segments

### DIFF
--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 func TestServerParameters(t *testing.T) {
@@ -239,6 +239,171 @@ func TestWalLevel(t *testing.T) {
 	walLevel = pgParameters["wal_level"]
 	if walLevel != "logical" {
 		t.Fatalf("unexpected wal_level value: %q", walLevel)
+	}
+}
+
+func TestWalKeepSegments(t *testing.T) {
+	t.Parallel()
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	tstore, err := NewTestStore(t, dir)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tstore.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tstore.WaitUp(10 * time.Second); err != nil {
+		t.Fatalf("error waiting on store up: %v", err)
+	}
+	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
+	defer tstore.Stop()
+
+	clusterName := uuid.NewV4().String()
+
+	storePath := filepath.Join(common.StorePrefix, clusterName)
+
+	sm := store.NewKVBackedStore(tstore.store, storePath)
+
+	initialClusterSpec := &cluster.ClusterSpec{
+		InitMode:           cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
+		SleepInterval:      &cluster.Duration{Duration: 2 * time.Second},
+		FailInterval:       &cluster.Duration{Duration: 5 * time.Second},
+		ConvergenceTimeout: &cluster.Duration{Duration: 30 * time.Second},
+	}
+	initialClusterSpecFile, err := writeClusterSpec(dir, initialClusterSpec)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	ts, err := NewTestSentinel(t, dir, clusterName, tstore.storeBackend, storeEndpoints, fmt.Sprintf("--initial-cluster-spec=%s", initialClusterSpecFile))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := ts.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	tk, err := NewTestKeeper(t, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := WaitClusterPhase(sm, cluster.ClusterPhaseNormal, 60*time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.WaitDBUp(60 * time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	// "archive" isn't an accepted wal_level
+	err = StolonCtl(clusterName, tstore.storeBackend, storeEndpoints, "update", "--patch", `{ "pgParameters" : { "wal_level": "archive" } }`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.cmd.ExpectTimeout("postgres parameters not changed", 30*time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	tk.Stop()
+	if err := tk.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.WaitDBUp(60 * time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	pgParameters, err := tk.GetPGParameters()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	walKeepSegments := pgParameters["wal_keep_segments"]
+	if walKeepSegments != "8" {
+		t.Fatalf("unexpected wal_keep_segments value: %q", walKeepSegments)
+	}
+
+	// test setting a wal_keep_segments value greater than the default
+	err = StolonCtl(clusterName, tstore.storeBackend, storeEndpoints, "update", "--patch", `{ "pgParameters" : { "wal_keep_segments": "20" } }`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.cmd.ExpectTimeout("postgres parameters changed, reloading postgres instance", 30*time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	tk.Stop()
+	if err := tk.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.WaitDBUp(60 * time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	pgParameters, err = tk.GetPGParameters()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	walKeepSegments = pgParameters["wal_keep_segments"]
+	if walKeepSegments != "20" {
+		t.Fatalf("unexpected wal_keep_segments value: %q", walKeepSegments)
+	}
+
+	// test setting a wal_keep_segments value less than the default
+	err = StolonCtl(clusterName, tstore.storeBackend, storeEndpoints, "update", "--patch", `{ "pgParameters" : { "wal_keep_segments": "5" } }`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if err := tk.cmd.ExpectTimeout("postgres parameters changed, reloading postgres instance", 30*time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	tk.Stop()
+	if err := tk.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.WaitDBUp(60 * time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	pgParameters, err = tk.GetPGParameters()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	walKeepSegments = pgParameters["wal_keep_segments"]
+	if walKeepSegments != "8" {
+		t.Fatalf("unexpected wal_keep_segments value: %q", walKeepSegments)
+	}
+
+	// test setting a bad wal_keep_segments value
+	err = StolonCtl(clusterName, tstore.storeBackend, storeEndpoints, "update", "--patch", `{ "pgParameters" : { "wal_keep_segments": "badvalue" } }`)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	tk.Stop()
+	if err := tk.Start(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if err := tk.WaitDBUp(60 * time.Second); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	pgParameters, err = tk.GetPGParameters()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	walKeepSegments = pgParameters["wal_keep_segments"]
+	if walKeepSegments != "8" {
+		t.Fatalf("unexpected wal_keep_segments value: %q", walKeepSegments)
 	}
 }
 


### PR DESCRIPTION
use the value provided in the pg parameters to set the instance
wal_keep_segments value.

The value is ignored if it's a bad value or lesser than the default value (8).