### PR TITLE
Label cluster identifier with component

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -85,9 +85,9 @@ var (
 	clusterIdentifier = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "stolon_cluster_identifier",
-			Help: "Set to 1, is labelled with the cluster_name",
+			Help: "Set to 1, is labelled with the cluster_name and component",
 		},
-		[]string{"cluster_name"},
+		[]string{"cluster_name", "component"},
 	)
 )
 
@@ -127,8 +127,8 @@ func CheckCommonConfig(cfg *CommonConfig) error {
 // SetMetrics should be called by any stolon component that outputs application metrics.
 // It sets the clusterIdentifier metric, which is key to joining across all the other
 // metric series.
-func SetMetrics(cfg *CommonConfig) {
-	clusterIdentifier.WithLabelValues(cfg.ClusterName).Set(1)
+func SetMetrics(cfg *CommonConfig, component string) {
+	clusterIdentifier.WithLabelValues(cfg.ClusterName, component).Set(1)
 }
 
 func IsColorLoggerEnable(cmd *cobra.Command, cfg *CommonConfig) bool {

--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1873,7 +1873,7 @@ func keeper(c *cobra.Command, args []string) {
 		log.Fatalf(err.Error())
 	}
 
-	cmd.SetMetrics(&cfg.CommonConfig)
+	cmd.SetMetrics(&cfg.CommonConfig, "keeper")
 
 	if err = os.MkdirAll(cfg.dataDir, 0700); err != nil {
 		log.Fatalf("cannot create data dir: %v", err)

--- a/cmd/proxy/cmd/proxy.go
+++ b/cmd/proxy/cmd/proxy.go
@@ -352,6 +352,8 @@ func proxy(c *cobra.Command, args []string) {
 		log.Fatalf(err.Error())
 	}
 
+	cmd.SetMetrics(&cfg.CommonConfig, "proxy")
+
 	if cfg.keepAliveIdle < 0 {
 		log.Fatalf("tcp keepalive idle value must be greater or equal to 0")
 	}

--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -1961,7 +1961,7 @@ func sentinel(c *cobra.Command, args []string) {
 		log.Fatalf(err.Error())
 	}
 
-	cmd.SetMetrics(&cfg.CommonConfig)
+	cmd.SetMetrics(&cfg.CommonConfig, "sentinel")
 
 	uid := common.UID()
 	log.Infow("sentinel uid", "uid", uid)


### PR DESCRIPTION
[^1]: https://github.com/gocardless/stolon-pgbouncer/pull/46

The stolon_cluster_identifier metric is universal to all stolon
components, and can be used to join metric series across a stolon
cluster. By adding the component label, it's possible to write
polymorphic alerts that expose the component name when firing.

This change also registers the metric in the sentinel and proxy, as it
should be present in all long-lived binaries. This accompanies a change
in stolon-pgbouncer to do the same[^1].