### PR TITLE
Allow cluster to recover during partial storage failure

### DIFF
--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   serviceName: "stolon-keeper"
   replicas: 2
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels:


### PR DESCRIPTION
podManagementPolicy: Parallel prevents the following situation:

1. We run Stolon as a StatefulSet with 2 or more replicas
2. The cluster goes down together with storage system
3. The cluster comes up. The storage system comes up partially, with Persistent Volume 0 still unavailable.
4. Kubernetes fails to re-schedule and start the StatefulSet since storage for replica 0 is still down.

The Parallel policy tells Kubernetes to start other replicas without waiting for replicas with lower ordinal numbers.