### PR TITLE
Use agola CI/CD

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -1,0 +1,101 @@
+local go_runtime(version, arch) = {
+  type: 'pod',
+  arch: arch,
+  containers: [
+    {
+      image: 'golang:' + version + '-buster',
+    },
+  ],
+};
+
+local ci_runtime(pgversion, arch) = {
+  type: 'pod',
+  arch: arch,
+  containers: [
+    {
+      image: 'sorintlab/stolon-ci-image:v0.1.0-pg' + pgversion,
+      volumes: [
+        {
+          path: '/stolontemp',
+          tmpfs: {},
+        },
+      ],
+    },
+  ],
+};
+
+local task_build_go(version, arch) = {
+  name: 'build go ' + version + ' ' + arch,
+  runtime: go_runtime(version, arch),
+  environment: {
+    GO111MODULE: 'on',
+  },
+  steps: [
+    { type: 'clone' },
+    { type: 'restore_cache', keys: ['cache-sum-{{ md5sum "go.sum" }}', 'cache-date-'], dest_dir: '/go/pkg/mod/cache' },
+    { type: 'run', command: './build' },
+    { type: 'run', command: './test' },
+    { type: 'run', name: 'build integration tests binary', command: 'go test -c ./tests/integration/ -o bin/integration-tests' },
+    { type: 'save_cache', key: 'cache-sum-{{ md5sum "go.sum" }}', contents: [{ source_dir: '/go/pkg/mod/cache' }] },
+    { type: 'save_cache', key: 'cache-date-{{ year }}-{{ month }}-{{ day }}', contents: [{ source_dir: '/go/pkg/mod/cache' }] },
+    { type: 'save_to_workspace', contents: [{ source_dir: './bin', dest_dir: '/bin/', paths: ['*'] }] },
+  ],
+};
+
+local task_integration_tests(store, pgversion, arch) = {
+  name: 'integration tests store: ' + store + ', postgres: ' + pgversion + ', arch: ' + arch,
+  runtime: ci_runtime(pgversion, 'amd64'),
+  environment: {
+    STOLON_TEST_STORE_BACKEND: store,
+    POSTGRES_PATH: '/usr/lib/postgresql/' + pgversion,
+  },
+  steps: [
+    { type: 'restore_workspace', dest_dir: '.' },
+    {
+      type: 'run',
+      name: 'test',
+      command: |||
+        export TMPDIR=/stolontemp
+        export PATH=$POSTGRES_PATH:$PATH
+        export BINDIR=${PWD}/bin
+        export STKEEPER_BIN=${BINDIR}/stolon-keeper
+        export STSENTINEL_BIN=${BINDIR}/stolon-sentinel
+        export STPROXY_BIN=${BINDIR}/stolon-proxy
+        export STCTL_BIN=${BINDIR}/stolonctl
+        export ETCD_BIN="${HOME}/etcd/etcd"
+        export CONSUL_BIN="${HOME}/consul"
+        INTEGRATION=1 ./bin/integration-tests -test.parallel 2 -test.v
+      |||,
+    },
+  ],
+  depends: [
+    'build go 1.13 ' + arch,
+  ],
+};
+
+{
+  runs: [
+    {
+      name: 'stolon build/test',
+      tasks: std.flattenArrays([
+        [
+          task_build_go(version, arch),
+        ]
+        for version in ['1.12', '1.13']
+        for arch in ['amd64' /*, 'arm64' */]
+      ]) + std.flattenArrays([
+        [
+          task_integration_tests(store, pgversion, 'amd64'),
+        ]
+        for store in ['etcdv2', 'consul']
+        for pgversion in ['11' /*, '12' */]
+      ]) + std.flattenArrays([
+        [
+          task_integration_tests(store, pgversion, 'amd64'),
+        ]
+        for store in ['etcdv3']
+        for pgversion in ['9.5', '9.6', '10', '11' /*, '12' */]
+      ]),
+    },
+  ],
+}

--- a/build
+++ b/build
@@ -42,9 +42,9 @@ if [ -w ${go_root_dir}/pkg ]; then
 fi
 
 for cmd in sentinel proxy; do
-  echo "Building stolon-${cmd} ..."
+	echo "Building stolon-${cmd} ..."
 	CGO_ENABLED=0 go build -installsuffix cgo -ldflags "$LD_FLAGS" -o ${BINDIR}/stolon-${cmd} ${REPO_PATH}/cmd/${cmd}
-  echo "Done building stolon-${cmd}"
+	echo "Done building stolon-${cmd}"
 done
 
 echo "Building stolonctl ..."
@@ -61,10 +61,10 @@ declare -a DOCKERFILE_PATHS
 DOCKERFILE_PATHS=(${BASEDIR}/examples/kubernetes/image/docker)
 for path in "${DOCKERFILE_PATHS[@]}"
 do
-  rm -rf $path/bin/
-  mkdir -p $path/bin/
-  for cmd in stolon-keeper stolon-sentinel stolon-proxy stolonctl; do
-          cp ${BINDIR}/${cmd} $path/bin/
-  done
+	rm -rf $path/bin/
+	mkdir -p $path/bin/
+	for cmd in stolon-keeper stolon-sentinel stolon-proxy stolonctl; do
+		cp ${BINDIR}/${cmd} $path/bin/
+	done
 done
 echo "Done!"

--- a/test
+++ b/test
@@ -61,7 +61,7 @@ echo "Checking govet -shadow ..."
 go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 export PATH=${GOPATH}/bin:${PATH}
 shadow_tool=$(which shadow)
-vetRes=$(go vet -vettool="${shadow_tool}" ${PACKAGES})
+vetRes=$(${shadow_tool} ${PACKAGES})
 if [ -n "${vetRes}" ]; then
 	echo -e "govet checking ${path} failed:\n${vetRes}"
 	exit 255


### PR DESCRIPTION
Implement initial run definition for agola CI/CD. It'll use the latest two go
versions (currently 1.12 and 1.13)

Add a test matrix for all the supported postgres version and stores (for etcdv2
and consul just test with the latest postgres version)

In future will add automatic docker example image build and push