### PR TITLE
k8s example: update deployment api

### DIFF
--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -1,13 +1,17 @@
 # PetSet was renamed to StatefulSet in k8s 1.5
 # apiVersion: apps/v1alpha1
 # kind: PetSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: stolon-keeper
 spec:
   serviceName: "stolon-keeper"
   replicas: 2
+  selector:
+    matchLabels:
+      component: stolon-keeper
+      stolon-cluster: kube-stolon
   template:
     metadata:
       labels:
@@ -20,55 +24,55 @@ spec:
     spec:
       terminationGracePeriodSeconds: 10
       containers:
-      - name: stolon-keeper
-        image: sorintlab/stolon:master-pg10
-        command:
-          - "/bin/bash"
-          - "-ec"
-          - |
-            # Generate our keeper uid using the pod index
-            IFS='-' read -ra ADDR <<< "$(hostname)"
-            export STKEEPER_UID="keeper${ADDR[-1]}"
-            export POD_IP=$(hostname -i)
-            export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
-            export STOLON_DATA=/stolon-data
-            chown stolon:stolon $STOLON_DATA
-            exec gosu stolon stolon-keeper --data-dir $STOLON_DATA
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: STKEEPER_CLUSTER_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['stolon-cluster']
-          - name: STKEEPER_STORE_BACKEND
-            value: "kubernetes"
-          - name: STKEEPER_KUBE_RESOURCE_KIND
-            value: "configmap"
-          - name: STKEEPER_PG_REPL_USERNAME
-            value: "repluser"
-            # Or use a password file like in the below supersuser password
-          - name: STKEEPER_PG_REPL_PASSWORD
-            value: "replpassword"
-          - name: STKEEPER_PG_SU_USERNAME
-            value: "stolon"
-          - name: STKEEPER_PG_SU_PASSWORDFILE
-            value: "/etc/secrets/stolon/password"
-          - name: STKEEPER_METRICS_LISTEN_ADDRESS
-            value: "0.0.0.0:8080"
-          # Uncomment this to enable debug logs
-          #- name: STKEEPER_DEBUG
-          #  value: "true"
-        ports:
-          - containerPort: 5432
-          - containerPort: 8080
-        volumeMounts:
-        - mountPath: /stolon-data
-          name: data
-        - mountPath: /etc/secrets/stolon
-          name: stolon
+        - name: stolon-keeper
+          image: sorintlab/stolon:master-pg10
+          command:
+            - "/bin/bash"
+            - "-ec"
+            - |
+              # Generate our keeper uid using the pod index
+              IFS='-' read -ra ADDR <<< "$(hostname)"
+              export STKEEPER_UID="keeper${ADDR[-1]}"
+              export POD_IP=$(hostname -i)
+              export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
+              export STOLON_DATA=/stolon-data
+              chown stolon:stolon $STOLON_DATA
+              exec gosu stolon stolon-keeper --data-dir $STOLON_DATA
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STKEEPER_CLUSTER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['stolon-cluster']
+            - name: STKEEPER_STORE_BACKEND
+              value: "kubernetes"
+            - name: STKEEPER_KUBE_RESOURCE_KIND
+              value: "configmap"
+            - name: STKEEPER_PG_REPL_USERNAME
+              value: "repluser"
+              # Or use a password file like in the below supersuser password
+            - name: STKEEPER_PG_REPL_PASSWORD
+              value: "replpassword"
+            - name: STKEEPER_PG_SU_USERNAME
+              value: "stolon"
+            - name: STKEEPER_PG_SU_PASSWORDFILE
+              value: "/etc/secrets/stolon/password"
+            - name: STKEEPER_METRICS_LISTEN_ADDRESS
+              value: "0.0.0.0:8080"
+            # Uncomment this to enable debug logs
+            #- name: STKEEPER_DEBUG
+            #  value: "true"
+          ports:
+            - containerPort: 5432
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: /stolon-data
+              name: data
+            - mountPath: /etc/secrets/stolon
+              name: stolon
       volumes:
         - name: stolon
           secret:
@@ -76,12 +80,12 @@ spec:
   # Define your own volumeClaimTemplate. This example uses dynamic PV provisioning with a storage class named "standard" (so it will works by default with minikube)
   # In production you should use your own defined storage-class and configure your persistent volumes (statically or dynamically using a provisioner, see related k8s doc).
   volumeClaimTemplates:
-  - metadata:
-      name: data
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: standard
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 512Mi
+    - metadata:
+        name: data
+        annotations:
+          volume.alpha.kubernetes.io/storage-class: standard
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 512Mi

--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: stolon-proxy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      component: stolon-proxy
+      stolon-cluster: kube-stolon
   template:
     metadata:
       labels:
@@ -14,38 +18,38 @@ spec:
         prometheus.io/port: "8080"
     spec:
       containers:
-      - name: stolon-proxy
-        image: sorintlab/stolon:master-pg10
-        command:
-          - "/bin/bash"
-          - "-ec"
-          - |
-            exec gosu stolon stolon-proxy
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: STPROXY_CLUSTER_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['stolon-cluster']
-          - name: STPROXY_STORE_BACKEND
-            value: "kubernetes"
-          - name: STPROXY_KUBE_RESOURCE_KIND
-            value: "configmap"
-          - name: STPROXY_LISTEN_ADDRESS
-            value: "0.0.0.0"
-          - name: STPROXY_METRICS_LISTEN_ADDRESS
-            value: "0.0.0.0:8080"
-          ## Uncomment this to enable debug logs
-          #- name: STPROXY_DEBUG
-          #  value: "true"
-        ports:
-          - containerPort: 5432
-          - containerPort: 8080
-        readinessProbe:
-          tcpSocket:
-            port: 5432
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
+        - name: stolon-proxy
+          image: sorintlab/stolon:master-pg10
+          command:
+            - "/bin/bash"
+            - "-ec"
+            - |
+              exec gosu stolon stolon-proxy
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STPROXY_CLUSTER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['stolon-cluster']
+            - name: STPROXY_STORE_BACKEND
+              value: "kubernetes"
+            - name: STPROXY_KUBE_RESOURCE_KIND
+              value: "configmap"
+            - name: STPROXY_LISTEN_ADDRESS
+              value: "0.0.0.0"
+            - name: STPROXY_METRICS_LISTEN_ADDRESS
+              value: "0.0.0.0:8080"
+            ## Uncomment this to enable debug logs
+            #- name: STPROXY_DEBUG
+            #  value: "true"
+          ports:
+            - containerPort: 5432
+            - containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 10
+            timeoutSeconds: 5

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: stolon-sentinel
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      component: stolon-sentinel
+      stolon-cluster: kube-stolon
   template:
     metadata:
       labels:
@@ -14,30 +18,30 @@ spec:
         prometheus.io/port: "8080"
     spec:
       containers:
-      - name: stolon-sentinel
-        image: sorintlab/stolon:master-pg10
-        command:
-          - "/bin/bash"
-          - "-ec"
-          - |
-            exec gosu stolon stolon-sentinel
-        env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: STSENTINEL_CLUSTER_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.labels['stolon-cluster']
-          - name: STSENTINEL_STORE_BACKEND
-            value: "kubernetes"
-          - name: STSENTINEL_KUBE_RESOURCE_KIND
-            value: "configmap"
-          - name: STSENTINEL_METRICS_LISTEN_ADDRESS
-            value: "0.0.0.0:8080"
-          ## Uncomment this to enable debug logs
-          #- name: STSENTINEL_DEBUG
-          #  value: "true"
-        ports:
-          - containerPort: 8080
+        - name: stolon-sentinel
+          image: sorintlab/stolon:master-pg10
+          command:
+            - "/bin/bash"
+            - "-ec"
+            - |
+              exec gosu stolon stolon-sentinel
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: STSENTINEL_CLUSTER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['stolon-cluster']
+            - name: STSENTINEL_STORE_BACKEND
+              value: "kubernetes"
+            - name: STSENTINEL_KUBE_RESOURCE_KIND
+              value: "configmap"
+            - name: STSENTINEL_METRICS_LISTEN_ADDRESS
+              value: "0.0.0.0:8080"
+            ## Uncomment this to enable debug logs
+            #- name: STSENTINEL_DEBUG
+            #  value: "true"
+          ports:
+            - containerPort: 8080


### PR DESCRIPTION
new k8s version use `apiVersion: apps/v1` and don't support `apiVersion:
extensions/v1beta1` anymore. They also require a selector to matching the
managed pods.