### PR TITLE
agola ci: add k8s tests

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -141,6 +141,26 @@ local task_build_push_images(name, pgversions, istag, push) =
           ],
           depends: [],
         },
+        {
+          name: 'k8s test',
+          runtime: {
+            arch: 'amd64',
+            containers: [
+              {
+                image: 'bsycorp/kind:v1.15.1',
+                privileged: true,
+                entrypoint: '/usr/bin/supervisord --nodaemon -c /etc/supervisord.conf',
+              },
+            ],
+          },
+          working_dir: '/stolon',
+          steps: [
+            { type: 'restore_workspace', dest_dir: '/stolon' },
+            { type: 'run', command: 'apk add bash' },
+            { type: 'run', command: './scripts/agola-k8s.sh' },
+          ],
+          depends: ['checkout code and save to workspace'],
+        },
       ] + std.flattenArrays([
         [
           task_build_go(version, arch),

--- a/scripts/agola-k8s.sh
+++ b/scripts/agola-k8s.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+apk add make jq
+
+echo -n "Waiting for docker to be ready"
+until curl -s --fail http://127.0.0.1:10080/docker-ready; do
+    sleep 1;
+    echo -n "."
+done
+echo " Ready"
+
+cd /stolon
+
+make PGVERSION=11 TAG=stolon:master-pg11 docker
+
+pushd examples/kubernetes
+
+sed -i 's#sorintlab/stolon:master-pg10#stolon:master-pg11#' *.yaml
+
+for i in role.yaml role-binding.yaml secret.yaml stolon-sentinel.yaml stolon-keeper.yaml stolon-proxy.yaml stolon-proxy-service.yaml ; do
+	kubectl apply -f $i
+done
+
+popd
+
+KUBERUN="kubectl run --quiet -i -t stolonctl --image=stolon:master-pg11 --restart=Never --rm --"
+
+$KUBERUN /usr/local/bin/stolonctl --cluster-name=kube-stolon --store-backend=kubernetes --kube-resource-kind=configmap init -y
+
+OK=false
+COUNT=0
+while [ $COUNT -lt 120 ]; do
+	OUT=$($KUBERUN /usr/local/bin/stolonctl --cluster-name kube-stolon --store-backend kubernetes --kube-resource-kind configmap clusterdata read | jq .cluster.status.phase)
+	if [ "$OUT" == '"normal"' ]; then
+		OK=true
+		break
+	fi
+
+	COUNT=$((COUNT + 1))
+	sleep 1
+done
+
+# report some debug output
+kubectl get all
+$KUBERUN /usr/local/bin/stolonctl --cluster-name kube-stolon --store-backend kubernetes --kube-resource-kind configmap status
+$KUBERUN /usr/local/bin/stolonctl --cluster-name kube-stolon --store-backend kubernetes --kube-resource-kind configmap clusterdata read | jq .
+
+if [ "$OK" != "true" ]; then
+	echo "stolon cluster not correctly setup"
+	exit 1
+fi
+
+echo "stolon cluster successfully setup"


### PR DESCRIPTION
* Use bsycorp/kind image to start an already setup k8s cluster inside a
container. We aren't using kubernetes-sigs/kind because it will create a k8s in
docker in docker (two layers) that will take time to setup and won't work inside
a k8s pod without special mounting of host cgroups (due to systemd issues)

* Build the stolon image and push it to the kind cluster internal image store.

* Deploy stolon on k8s using the example deployment