### PR TITLE
*: add support for PostgreSQL 12

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -13,7 +13,7 @@ local ci_runtime(pgversion, arch) = {
   arch: arch,
   containers: [
     {
-      image: 'sorintlab/stolon-ci-image:v0.1.0-pg' + pgversion,
+      image: 'sorintlab/stolon-ci-image:v0.2.0-pg' + pgversion,
       volumes: [
         {
           path: '/stolontemp',
@@ -172,15 +172,15 @@ local task_build_push_images(name, pgversions, istag, push) =
           task_integration_tests(store, pgversion, 'amd64'),
         ]
         for store in ['etcdv2', 'consul']
-        for pgversion in ['11' /*, '12' */]
+        for pgversion in ['12']
       ]) + std.flattenArrays([
         [
           task_integration_tests(store, pgversion, 'amd64'),
         ]
         for store in ['etcdv3']
-        for pgversion in ['9.5', '9.6', '10', '11' /*, '12' */]
+        for pgversion in ['9.5', '9.6', '10', '11', '12']
       ]) + [
-        task_build_push_images('test build docker "stolon" images', '9.4 9.5 9.6 10 11', false, false)
+        task_build_push_images('test build docker "stolon" images', '9.4 9.5 9.6 10 11 12', false, false)
         + {
           when: {
             branch: {
@@ -190,13 +190,13 @@ local task_build_push_images(name, pgversions, istag, push) =
             ref: '#refs/pull/\\d+/head#',
           },
         },
-        task_build_push_images('build and push docker "stolon" master branch images', '9.4 9.5 9.6 10 11', false, true)
+        task_build_push_images('build and push docker "stolon" master branch images', '9.4 9.5 9.6 10 11 12', false, true)
         + {
           when: {
             branch: 'master',
           },
         },
-        task_build_push_images('build and push docker "stolon" tag images', '9.4 9.5 9.6 10 11', true, true)
+        task_build_push_images('build and push docker "stolon" tag images', '9.4 9.5 9.6 10 11 12', true, true)
         + {
           when: {
             tag: '#v.*#',

--- a/internal/postgresql/utils.go
+++ b/internal/postgresql/utils.go
@@ -453,7 +453,7 @@ func isRestartRequiredUsingPgSettingsContext(ctx context.Context, connParams Con
 }
 
 func ParseBinaryVersion(v string) (int, int, error) {
-	// extact version (removing beta*, rc* etc...)
+	// extract version (removing beta*, rc* etc...)
 	regex, err := regexp.Compile(`.* \(PostgreSQL\) ([0-9\.]+).*`)
 	if err != nil {
 		return 0, 0, err

--- a/test
+++ b/test
@@ -57,7 +57,7 @@ fi
 
 echo "Checking govet -shadow ..."
 go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-export PATH=${GOPATH}/bin:${PATH}
+export PATH="$(go env GOPATH)/bin":${PATH}
 shadow_tool=$(which shadow)
 vetRes=$(${shadow_tool} ${PACKAGES})
 if [ -n "${vetRes}" ]; then

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 func TestPITR(t *testing.T) {
@@ -173,7 +174,9 @@ func testPITR(t *testing.T, recoveryTarget bool) {
 
 	if recoveryTarget {
 		initialClusterSpec.PITRConfig.RecoveryTargetSettings = &cluster.RecoveryTargetSettings{
-			RecoveryTargetTime: now.Format(time.RFC3339),
+			// Looks like Postgres12 cannot parse locations in UTC TZ like "2019-11-19T12:10:54Z" that previous versions were able to parse
+			// workaround this by not writing the timezone
+			RecoveryTargetTime: now.Format("2006-01-02T15:04:05"),
 		}
 	}
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -443,9 +443,18 @@ func (tk *TestKeeper) PGDataVersion() (int, int, error) {
 }
 
 func (tk *TestKeeper) GetPrimaryConninfo() (pg.ConnParams, error) {
+	maj, _, err := tk.PGDataVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	confFile := "recovery.conf"
+	if maj >= 12 {
+		confFile = "postgresql.conf"
+	}
 	regex := regexp.MustCompile(`\s*primary_conninfo\s*=\s*'(.*)'$`)
 
-	fh, err := os.Open(filepath.Join(tk.dataDir, "postgres", "recovery.conf"))
+	fh, err := os.Open(filepath.Join(tk.dataDir, "postgres", confFile))
 	if os.IsNotExist(err) {
 		return nil, nil
 	}


### PR DESCRIPTION
PostgreSQL 12 changed how it manages recovery and standby:

* The "recovery.conf" file has been removed.
* Recovery parameters now live in "postgresql.conf"
* "standby_mode" recovery parameter has been removed.
* Two "signal" files ("recovery.signal" and "standby.signal") are used to define
  the recovery mode (instead of using a "recovery.conf" file + "standby_mode" parameter)

Resolves #709 