### PR TITLE
Use service name instead of querying the service to get its IP to connect to the DB

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -105,20 +105,12 @@ kubectl create -f stolon-proxy-service.yaml
 
 ### Connect to the db
 
-#### Get the proxy service ip
-
-```
-kubectl get svc
-NAME                   LABELS                                    SELECTOR                                       IP(S)           PORT(S)
-stolon-proxy-service   <none>                                    stolon-cluster=kube-stolon,stolon-proxy=true   10.247.50.217   5432/TCP
-```
-
 #### Connect to the proxy service
 
 The password for the stolon user will be the value specified in your `secret.yaml` above (or `password1` if you did not change it).
 
 ```
-psql --host 10.247.50.217 --port 5432 postgres -U stolon -W
+psql --host stolon-proxy-service  --port 5432 postgres -U stolon -W
 Password for user stolon:
 psql (9.4.5, server 9.4.4)
 Type "help" for help.


### PR DESCRIPTION
Querying service for its IP to connect to the database is too tedious and not needed when we can query directly with service name.