### PR TITLE
keeper: remove duplicate package import

### DIFF
--- a/cmd/keeper/cmd/keeper_test.go
+++ b/cmd/keeper/cmd/keeper_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	mocks "github.com/sorintlab/stolon/internal/mock/postgresql"
-	"github.com/sorintlab/stolon/internal/postgresql"
+	pgmocks "github.com/sorintlab/stolon/internal/mock/postgresql"
+	pg "github.com/sorintlab/stolon/internal/postgresql"
 
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
@@ -276,8 +276,8 @@ func TestGetTimeLinesHistory(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		pgm := mocks.NewMockPGManager(ctrl)
-		pgm.EXPECT().GetTimelinesHistory(timelineID).Return([]*postgresql.TimelineHistory{}, fmt.Errorf("failed to get timeline history"))
+		pgm := pgmocks.NewMockPGManager(ctrl)
+		pgm.EXPECT().GetTimelinesHistory(timelineID).Return([]*pg.TimelineHistory{}, fmt.Errorf("failed to get timeline history"))
 		ctlsh, err := getTimeLinesHistory(pgState, pgm, 3)
 
 		if err == nil {
@@ -300,8 +300,8 @@ func TestGetTimeLinesHistory(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		pgm := mocks.NewMockPGManager(ctrl)
-		timelineHistories := []*postgresql.TimelineHistory{
+		pgm := pgmocks.NewMockPGManager(ctrl)
+		timelineHistories := []*pg.TimelineHistory{
 			{
 				TimelineID:  1,
 				SwitchPoint: 1,
@@ -352,8 +352,8 @@ func TestGetTimeLinesHistory(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		pgm := mocks.NewMockPGManager(ctrl)
-		timelineHistories := []*postgresql.TimelineHistory{
+		pgm := pgmocks.NewMockPGManager(ctrl)
+		timelineHistories := []*pg.TimelineHistory{
 			{
 				TimelineID:  1,
 				SwitchPoint: 1,

--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -35,7 +35,7 @@ import (
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/flagutil"
 	slog "github.com/sorintlab/stolon/internal/log"
-	"github.com/sorintlab/stolon/internal/postgresql"
+	pg "github.com/sorintlab/stolon/internal/postgresql"
 	"github.com/sorintlab/stolon/internal/store"
 	"github.com/sorintlab/stolon/internal/timer"
 	"github.com/sorintlab/stolon/internal/util"
@@ -581,8 +581,8 @@ func (s *Sentinel) dbCanSync(cd *cluster.ClusterData, dbUID string) bool {
 		return true
 	}
 
-	required := postgresql.XlogPosToWalFileNameNoTimeline(db.Status.XLogPos)
-	older, err := postgresql.WalFileNameNoTimeLine(masterDB.Status.OlderWalFile)
+	required := pg.XlogPosToWalFileNameNoTimeline(db.Status.XLogPos)
+	older, err := pg.WalFileNameNoTimeLine(masterDB.Status.OlderWalFile)
 	if err != nil {
 		// warn on wrong file name (shouldn't happen...)
 		log.Warnw("wrong wal file name", "filename", masterDB.Status.OlderWalFile)
@@ -1952,7 +1952,7 @@ func sentinel(c *cobra.Command, args []string) {
 	}
 	if cmd.IsColorLoggerEnable(c, &cfg.CommonConfig) {
 		log = slog.SColor()
-		postgresql.SetLogger(log)
+		pg.SetLogger(log)
 	}
 
 	if err := cmd.CheckCommonConfig(&cfg.CommonConfig); err != nil {


### PR DESCRIPTION
"github.com/sorintlab/stolon/internal/postgresql" was imported and used two
times with different names.

Also unify the package name in other files using this package.