### PR TITLE
Migrate resource api groups for kubernetes 1.16+

### DIFF
--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -1,13 +1,17 @@
 # PetSet was renamed to StatefulSet in k8s 1.5
 # apiVersion: apps/v1alpha1
 # kind: PetSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: stolon-keeper
 spec:
   serviceName: "stolon-keeper"
   replicas: 2
+  selector:
+    matchLabels:
+      component: stolon-keeper
+      stolon-cluster: kube-stolon
   template:
     metadata:
       labels:

--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: stolon-proxy
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      component: stolon-proxy
+      stolon-cluster: kube-stolon
   template:
     metadata:
       labels:

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: stolon-sentinel
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      component: stolon-sentinel
+      stolon-cluster: kube-stolon
   template:
     metadata:
       labels:


### PR DESCRIPTION
> The v1.16 release will stop serving the following deprecated API versions in favor of newer and more stable API versions:

> * DaemonSet, Deployment, StatefulSet, and ReplicaSet (in the extensions/v1beta1 and apps/v1beta2 API groups)
>   * Migrate to use the apps/v1 API, available since v1.9. Existing persisted data can be retrieved/updated via the apps/v1 API.

See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/