### PR TITLE
Make the k8s store properly patch annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/docker/libkv v0.2.1
 	github.com/emicklei/go-restful v2.5.0+incompatible // indirect
 	github.com/emicklei/go-restful-swagger12 v0.0.0-20170208215640-dcef7f557305 // indirect
+	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/go-openapi/jsonpointer v0.0.0-20170102174223-779f45308c19 // indirect
 	github.com/go-openapi/jsonreference v0.0.0-20161105162150-36d33bfe519e // indirect
 	github.com/go-openapi/spec v0.0.0-20180131233152-f3499b5df538 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/docker/leadership v0.1.0/go.mod h1:6yL2hg00l43fYEJagcF7eIS4PootU7TAO1
 github.com/docker/libkv v0.2.1/go.mod h1:r5hEwHwW8dr0TFBYGCarMNbrQOiwL1xoqDYZ/JqoTK0=
 github.com/emicklei/go-restful v2.5.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful-swagger12 v0.0.0-20170208215640-dcef7f557305/go.mod h1:qr0VowGBT4CS4Q8vFF8BSeKz34PuqKGxs/L0IAQA9DQ=
+github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/internal/store/k8s.go
+++ b/internal/store/k8s.go
@@ -23,10 +23,12 @@ import (
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/util"
 
+	jsonpatch "github.com/evanphx/json-patch"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -216,11 +218,28 @@ func (s *KubeStore) SetKeeperInfo(ctx context.Context, id string, ms *cluster.Ke
 		if err != nil {
 			return fmt.Errorf("failed to get latest version of pod: %v", err)
 		}
-		if result.Annotations == nil {
-			result.Annotations = map[string]string{}
+
+		oldData, err := json.Marshal(result)
+		if err != nil {
+			return err
 		}
-		result.Annotations[util.KubeStatusAnnnotation] = string(msj)
-		_, err = podsClient.Update(result)
+
+		if result.ObjectMeta.Annotations == nil {
+			result.ObjectMeta.Annotations = map[string]string{}
+		}
+		result.ObjectMeta.Annotations[util.KubeStatusAnnnotation] = string(msj)
+
+		newData, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+
+		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+		if err != nil {
+			return err
+		}
+
+		_, err = podsClient.Patch(s.podName, types.MergePatchType, patchBytes)
 		return err
 	})
 	if retryErr != nil {
@@ -265,13 +284,30 @@ func (s *KubeStore) SetSentinelInfo(ctx context.Context, si *cluster.SentinelInf
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		result, err := podsClient.Get(s.podName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get latest version of pod: %v", err)
+			return err
 		}
-		if result.Annotations == nil {
-			result.Annotations = map[string]string{}
+
+		oldData, err := json.Marshal(result)
+		if err != nil {
+			return err
 		}
-		result.Annotations[util.KubeStatusAnnnotation] = string(sij)
-		_, err = podsClient.Update(result)
+
+		if result.ObjectMeta.Annotations == nil {
+			result.ObjectMeta.Annotations = map[string]string{}
+		}
+		result.ObjectMeta.Annotations[util.KubeStatusAnnnotation] = string(sij)
+
+		newData, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+
+		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+		if err != nil {
+			return err
+		}
+
+		_, err = podsClient.Patch(s.podName, types.MergePatchType, patchBytes)
 		return err
 	})
 	if retryErr != nil {
@@ -316,13 +352,30 @@ func (s *KubeStore) SetProxyInfo(ctx context.Context, pi *cluster.ProxyInfo, ttl
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		result, err := podsClient.Get(s.podName, metav1.GetOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to get latest version of pod: %v", err)
+			return err
 		}
-		if result.Annotations == nil {
-			result.Annotations = map[string]string{}
+
+		oldData, err := json.Marshal(result)
+		if err != nil {
+			return err
 		}
-		result.Annotations[util.KubeStatusAnnnotation] = string(pij)
-		_, err = podsClient.Update(result)
+
+		if result.ObjectMeta.Annotations == nil {
+			result.ObjectMeta.Annotations = map[string]string{}
+		}
+		result.ObjectMeta.Annotations[util.KubeStatusAnnnotation] = string(pij)
+
+		newData, err := json.Marshal(result)
+		if err != nil {
+			return err
+		}
+
+		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+		if err != nil {
+			return err
+		}
+
+		_, err = podsClient.Patch(s.podName, types.MergePatchType, patchBytes)
 		return err
 	})
 	if retryErr != nil {


### PR DESCRIPTION
Hi,

While trying out Stolon on Kubernetes, I ran into a weird issue where Stolon was unable to change the annotations on the sentinel and keeper pods. The api-server said it was trying to change some fields that were immutable. This was due to Stolon trying to replace the whole pod object instead of patching it.

This PRs changes the k8s store to properly use jsonpatch to set the annotations. This is heavily inspired by the way `kubectl annotate` does patch the annotations: https://github.com/kubernetes/kubectl/blob/b909fcb4a071a1a9669a9fe1f48482c848823124/pkg/cmd/annotate/annotate.go#L277-L311