### PR TITLE
k8s e.g.: Enable high availablility by NOT collocating pods on same node

### DIFF
--- a/examples/kubernetes/stolon-keeper.yaml
+++ b/examples/kubernetes/stolon-keeper.yaml
@@ -22,6 +22,16 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - stolon-keeper
+            topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
         - name: stolon-keeper

--- a/examples/kubernetes/stolon-proxy.yaml
+++ b/examples/kubernetes/stolon-proxy.yaml
@@ -17,6 +17,16 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - stolon-proxy
+            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: stolon-proxy
           image: sorintlab/stolon:master-pg10

--- a/examples/kubernetes/stolon-sentinel.yaml
+++ b/examples/kubernetes/stolon-sentinel.yaml
@@ -17,6 +17,16 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: component
+                operator: In
+                values:
+                - stolon-sentinel
+            topologyKey: "kubernetes.io/hostname"
       containers:
         - name: stolon-sentinel
           image: sorintlab/stolon:master-pg10


### PR DESCRIPTION
With this change, we ensure that the replica pods of the same
deployment do not get assigned to the same node. Fot this, we have
employed k8s anti-affinity rule.