### PR TITLE
Defer tabOut.Flush

### DIFF
--- a/cmd/stolonctl/cmd/status.go
+++ b/cmd/stolonctl/cmd/status.go
@@ -123,8 +123,8 @@ func renderText(status Status, generateErr error) {
 	} else {
 		fmt.Fprintf(tabOut, "ID\tLEADER\n")
 		for _, s := range status.Sentinels {
+			defer tabOut.Flush()
 			fmt.Fprintf(tabOut, "%s\t%t\n", s.UID, s.Leader)
-			tabOut.Flush()
 		}
 	}
 
@@ -136,8 +136,8 @@ func renderText(status Status, generateErr error) {
 	} else {
 		fmt.Fprintf(tabOut, "ID\n")
 		for _, p := range status.Proxies {
+			defer tabOut.Flush()
 			fmt.Fprintf(tabOut, "%s\n", p.UID)
-			tabOut.Flush()
 		}
 	}
 
@@ -150,8 +150,8 @@ func renderText(status Status, generateErr error) {
 	} else {
 		fmt.Fprintf(tabOut, "UID\tHEALTHY\tPG LISTENADDRESS\tPG HEALTHY\tPG WANTEDGENERATION\tPG CURRENTGENERATION\n")
 		for _, k := range status.Keepers {
+			defer tabOut.Flush()
 			fmt.Fprintf(tabOut, "%s\t%t\t%s\t%t\t%d\t%d\t\n", k.UID, k.Healthy, k.ListenAddress, k.PgHealthy, k.PgWantedGeneration, k.PgCurrentGeneration)
-			tabOut.Flush()
 		}
 	}
 


### PR DESCRIPTION
When running stolonctl status, i'm seeing the following output:

```
UID     HEALTHY PG LISTENADDRESS        PG HEALTHY      PG WANTEDGENERATION     PG CURRENTGENERATION
keeper0 true    10.1.0.36:5432          true            4                       4
keeper1 true    10.1.0.47:5432  true    2       2
```

instead of

```
UID     HEALTHY PG LISTENADDRESS        PG HEALTHY      PG WANTEDGENERATION     PG CURRENTGENERATION
keeper0 true    10.1.0.36:5432          true            2                       2
keeper1 true    10.1.0.47:5432          true            2                       2
```

Example: [https://play.golang.org/p/K9kBnGbYBEE](https://play.golang.org/p/K9kBnGbYBEE)