### PR TITLE
Add ETCDv3 client more statility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sorintlab/pollon v0.0.0-20181009091703-248c68238c16
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
-	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
+	go.etcd.io/etcd v0.5.0-alpha.5.0.20201125193152-8a03d2e9614b
 	go.uber.org/zap v1.13.0
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -56,7 +56,7 @@ const (
 	DefaultFailInterval                               = 20 * time.Second
 	DefaultDeadKeeperRemovalInterval                  = 48 * time.Hour
 	DefaultProxyCheckInterval                         = 5 * time.Second
-	DefaultProxyTimeout                               = 15 * time.Second
+	DefaultProxyTimeout                               = 20 * time.Second
 	DefaultMaxStandbys               uint16           = 20
 	DefaultMaxStandbysPerSender      uint16           = 3
 	DefaultMaxStandbyLag                              = 1024 * 1204

--- a/internal/store/kvbacked.go
+++ b/internal/store/kvbacked.go
@@ -185,6 +185,9 @@ func NewKVStore(cfg Config) (KVStore, error) {
 		config := etcdclientv3.Config{
 			Endpoints: addrs,
 			TLS:       tlsConfig,
+			DialTimeout: time.Second,
+			DialKeepAliveTime:    time.Second,
+			DialKeepAliveTimeout: 500 * time.Millisecond,
 		}
 
 		c, err := etcdclientv3.New(config)


### PR DESCRIPTION
Add ETCDv3 more statility:
- enable keepalive checks
  you must react on returned err code etcd3Lib functions
  Or enable keepalive for etcd3Lib for himself react on etcd cluster changes
  issue: https://github.com/sorintlab/stolon/issues/794
- update client libs to v.3.4.14
- grow proxy timeout to 20 sec, for skip proxy connections terminate when etcd cluster change leader
When etcd cluster changes leader node, stolon-proxy resets all connections but other components not failed.
Grow DefaultProxyTimeout 15-->20 sec can change this behaviour.