### PR TITLE
store: add etcdv3 timeouts

### DIFF
--- a/internal/store/kvbacked.go
+++ b/internal/store/kvbacked.go
@@ -183,8 +183,11 @@ func NewKVStore(cfg Config) (KVStore, error) {
 		return &libKVStore{store: store}, nil
 	case ETCDV3:
 		config := etcdclientv3.Config{
-			Endpoints: addrs,
-			TLS:       tlsConfig,
+			Endpoints:            addrs,
+			TLS:                  tlsConfig,
+			DialTimeout:          20 * time.Second,
+			DialKeepAliveTime:    1 * time.Second,
+			DialKeepAliveTimeout: cfg.Timeout,
 		}
 
 		c, err := etcdclientv3.New(config)


### PR DESCRIPTION
Add dial timeout and keep alive timeout to the etcdv3 client configuration or
under some network problems (not tcp reset from server) the client will never
try other etcd endpoints.