### PR TITLE
Added SCRAM-SHA-256 support

### DIFF
--- a/cmd/keeper/cmd/keeper.go
+++ b/cmd/keeper/cmd/keeper.go
@@ -1892,6 +1892,7 @@ func keeper(c *cobra.Command, args []string) {
 	validAuthMethods := make(map[string]struct{})
 	validAuthMethods["trust"] = struct{}{}
 	validAuthMethods["md5"] = struct{}{}
+	validAuthMethods["scram-sha-256"] = struct{}{}
 	switch cfg.LogLevel {
 	case "error":
 		slog.SetLevel(zap.ErrorLevel)

--- a/internal/postgresql/postgresql.go
+++ b/internal/postgresql/postgresql.go
@@ -217,7 +217,8 @@ func (p *Manager) Init(initConfig *InitConfig) error {
 
 	name := filepath.Join(p.pgBinPath, "initdb")
 	cmd := exec.Command(name, "-D", p.dataDir, "-U", p.suUsername)
-	if p.suAuthMethod == "md5" {
+	if p.suAuthMethod == "md5" || p.suAuthMethod == "scram-sha-256" {
+		cmd.Args = append(cmd.Args, "--auth", p.suAuthMethod)
 		cmd.Args = append(cmd.Args, "--pwfile", pwfile.Name())
 	}
 	log.Debugw("execing cmd", "cmd", cmd)


### PR DESCRIPTION
Fixes issue #776 as far as I can tell. These changes allow us to use SCRAM-SHA-256 authentication on the clusters we're running.