### PR TITLE
docker swarm 20.10 patch

### DIFF
--- a/examples/swarm/docker-compose-pg.yml
+++ b/examples/swarm/docker-compose-pg.yml
@@ -23,7 +23,7 @@ services:
 
   keeper1:
     image: sorintlab/stolon:master-pg10
-    hostname: keeper1
+    hostname: keeper1host
     environment:
       - PGDATA=/var/lib/postgresql/data
     volumes:
@@ -31,7 +31,7 @@ services:
     secrets:
       - pgsql
       - pgsql_repl
-    command: gosu stolon stolon-keeper --pg-listen-address keeper1 --pg-repl-username replication --uid keeper1 --pg-su-username postgres --pg-su-passwordfile /run/secrets/pgsql --pg-repl-passwordfile /run/secrets/pgsql_repl --data-dir /var/lib/postgresql/data --cluster-name stolon-cluster --store-backend=etcdv3 --store-endpoints http://etcd-00:2379,http://etcd-01:2379,http://etcd-02:2379 --log-level debug
+    command: gosu stolon stolon-keeper --pg-listen-address '*' --pg-advertise-address keeper1 --pg-repl-username replication --uid keeper1 --pg-su-username postgres --pg-su-passwordfile /run/secrets/pgsql --pg-repl-passwordfile /run/secrets/pgsql_repl --data-dir /var/lib/postgresql/data --cluster-name stolon-cluster --store-backend=etcdv3 --store-endpoints http://etcd-00:2379,http://etcd-01:2379,http://etcd-02:2379 --log-level debug
     networks:
       - etcd_etcd
       - pgdb
@@ -42,14 +42,14 @@ services:
 
   keeper2:
     image: sorintlab/stolon:master-pg10
-    hostname: keeper2
+    hostname: keeper2host
     environment:
       - PGDATA=/var/lib/postgresql/data
     volumes:
       - pgkeeper2:/var/lib/postgresql/data
     secrets:
       - pgsql
-    command: gosu stolon stolon-keeper --pg-listen-address keeper2 --pg-repl-username replication --uid keeper2 --pg-su-username postgres --pg-su-passwordfile /run/secrets/pgsql --pg-repl-passwordfile /run/secrets/pgsql --data-dir /var/lib/postgresql/data --cluster-name stolon-cluster --store-backend=etcdv3 --store-endpoints http://etcd-00:2379,http://etcd-01:2379,http://etcd-02:2379 --log-level debug
+    command: gosu stolon stolon-keeper --pg-listen-address '*' --pg-advertise-address keeper2 --pg-repl-username replication --uid keeper2 --pg-su-username postgres --pg-su-passwordfile /run/secrets/pgsql --pg-repl-passwordfile /run/secrets/pgsql --data-dir /var/lib/postgresql/data --cluster-name stolon-cluster --store-backend=etcdv3 --store-endpoints http://etcd-00:2379,http://etcd-01:2379,http://etcd-02:2379 --log-level debug
     networks:
       - etcd_etcd
       - pgdb


### PR DESCRIPTION
Proposed fix for: https://github.com/sorintlab/stolon/issues/835

Avoids breaking in Docker 20.10.x because of proxy switching continuously between the 2 ip addresses for the servicename and (since 20.10) the hostname.