### PR TITLE
gh-849: To check the cluster replication type based on cluster spec instead of masterdb spec

### DIFF
--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -1010,10 +1010,11 @@ func (s *Sentinel) updateCluster(cd *cluster.ClusterData, pis cluster.ProxiesInf
 			} else {
 				// if synchronous replication is enabled, only choose new master in the synchronous replication standbys.
 				var bestNewMasterDB *cluster.DB
-				if curMasterDB.Spec.SynchronousReplication {
+				if *cd.Cluster.Spec.SynchronousReplication {
 					commonSyncStandbys := util.CommonElements(curMasterDB.Status.SynchronousStandbys, curMasterDB.Spec.SynchronousStandbys)
 					if len(commonSyncStandbys) == 0 {
 						log.Warnw("cannot choose synchronous standby since there are no common elements between the latest master reported synchronous standbys and the db spec ones", "reported", curMasterDB.Status.SynchronousStandbys, "spec", curMasterDB.Spec.SynchronousStandbys)
+						bestNewMasterDB = bestNewMasters[0]
 					} else {
 						for _, nm := range bestNewMasters {
 							if util.StringInSlice(commonSyncStandbys, nm.UID) {

--- a/cmd/sentinel/cmd/sentinel_test.go
+++ b/cmd/sentinel/cmd/sentinel_test.go
@@ -597,10 +597,11 @@ func TestUpdateCluster(t *testing.T) {
 					UID:        "cluster1",
 					Generation: 1,
 					Spec: &cluster.ClusterSpec{
-						ConvergenceTimeout:   &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
-						InitTimeout:          &cluster.Duration{Duration: cluster.DefaultInitTimeout},
-						SyncTimeout:          &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
-						MaxStandbysPerSender: cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						ConvergenceTimeout:     &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
+						InitTimeout:            &cluster.Duration{Duration: cluster.DefaultInitTimeout},
+						SyncTimeout:            &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
+						MaxStandbysPerSender:   cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						SynchronousReplication: cluster.BoolP(false),
 					},
 					Status: cluster.ClusterStatus{
 						CurrentGeneration: 1,
@@ -685,10 +686,11 @@ func TestUpdateCluster(t *testing.T) {
 					UID:        "cluster1",
 					Generation: 1,
 					Spec: &cluster.ClusterSpec{
-						ConvergenceTimeout:   &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
-						InitTimeout:          &cluster.Duration{Duration: cluster.DefaultInitTimeout},
-						SyncTimeout:          &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
-						MaxStandbysPerSender: cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						ConvergenceTimeout:     &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
+						InitTimeout:            &cluster.Duration{Duration: cluster.DefaultInitTimeout},
+						SyncTimeout:            &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
+						MaxStandbysPerSender:   cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						SynchronousReplication: cluster.BoolP(false),
 					},
 					Status: cluster.ClusterStatus{
 						CurrentGeneration: 1,
@@ -1127,10 +1129,11 @@ func TestUpdateCluster(t *testing.T) {
 					UID:        "cluster1",
 					Generation: 1,
 					Spec: &cluster.ClusterSpec{
-						ConvergenceTimeout:   &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
-						InitTimeout:          &cluster.Duration{Duration: cluster.DefaultInitTimeout},
-						SyncTimeout:          &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
-						MaxStandbysPerSender: cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						ConvergenceTimeout:     &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
+						InitTimeout:            &cluster.Duration{Duration: cluster.DefaultInitTimeout},
+						SyncTimeout:            &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
+						MaxStandbysPerSender:   cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						SynchronousReplication: cluster.BoolP(false),
 					},
 					Status: cluster.ClusterStatus{
 						CurrentGeneration: 1,
@@ -1215,10 +1218,11 @@ func TestUpdateCluster(t *testing.T) {
 					UID:        "cluster1",
 					Generation: 1,
 					Spec: &cluster.ClusterSpec{
-						ConvergenceTimeout:   &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
-						InitTimeout:          &cluster.Duration{Duration: cluster.DefaultInitTimeout},
-						SyncTimeout:          &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
-						MaxStandbysPerSender: cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						ConvergenceTimeout:     &cluster.Duration{Duration: cluster.DefaultConvergenceTimeout},
+						InitTimeout:            &cluster.Duration{Duration: cluster.DefaultInitTimeout},
+						SyncTimeout:            &cluster.Duration{Duration: cluster.DefaultSyncTimeout},
+						MaxStandbysPerSender:   cluster.Uint16P(cluster.DefaultMaxStandbysPerSender),
+						SynchronousReplication: cluster.BoolP(false),
 					},
 					Status: cluster.ClusterStatus{
 						CurrentGeneration: 1,


### PR DESCRIPTION
Addresses https://github.com/sorintlab/stolon/issues/849

1.  When the primary failed and sync replica was failing and sentinel assigned SR as new primary

```
2021-10-06T14:44:31.522-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "f9aca2fc", "keeper": "postgres1"}
2021-10-06T14:44:31.522-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:44:36.740-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "f9aca2fc", "keeper": "postgres1"}
2021-10-06T14:44:36.740-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:44:36.750-0700	INFO	cmd/sentinel.go:995	master db is failed	{"db": "f9aca2fc", "keeper": "postgres1"}
2021-10-06T14:44:36.750-0700	INFO	cmd/sentinel.go:1006	trying to find a new master to replace failed master
2021-10-06T14:44:36.750-0700	INFO	cmd/sentinel.go:1032	electing db as the new master	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:44:42.018-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "f9aca2fc", "keeper": "postgres1"}
```

2. However SR also failed.
```
2021-10-06T14:44:47.334-0700	INFO	cmd/sentinel.go:1006	trying to find a new master to replace failed master
2021-10-06T14:44:47.334-0700	WARN	cmd/sentinel.go:1016	cannot choose synchronous standby since there are no common elements between the latest master reported synchronous standbys and the db spec ones	{"reported": [], "spec": ["f9aca2fc"]}
2021-10-06T14:44:47.334-0700	ERROR	cmd/sentinel.go:1035	no eligible masters
2021-10-06T14:44:52.581-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "f9aca2fc", "keeper": "postgres1"}
2021-10-06T14:44:52.581-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "1fe806fe", "keeper": "postgres3"}
```

3. Disabled synchronous replication and sentinel picked ASR as the new primary
```
2021-10-06T14:45:39.779-0700	INFO	cmd/sentinel.go:995	master db is failed	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:45:39.779-0700	INFO	cmd/sentinel.go:1001	db not converged	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:45:39.779-0700	INFO	cmd/sentinel.go:1006	trying to find a new master to replace failed master
2021-10-06T14:45:39.779-0700	INFO	cmd/sentinel.go:1032	electing db as the new master	{"db": "9665a7da", "keeper": "postgres2"}
2021-10-06T14:45:45.068-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "f9aca2fc", "keeper": "postgres1"}
2021-10-06T14:45:45.068-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:45:50.335-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:45:50.335-0700	WARN	cmd/sentinel.go:276	no keeper info available	{"db": "f9aca2fc", "keeper": "postgres1"}
2021-10-06T14:45:50.345-0700	INFO	cmd/sentinel.go:1151	removing old master db	{"db": "1fe806fe", "keeper": "postgres3"}
2021-10-06T14:45:50.345-0700	INFO	cmd/sentinel.go:1151	removing old master db	{"db": "f9aca2fc", "keeper": "postgres1"}
```