### PR TITLE
Switch uuid package to get around GO-2020-0018

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/docker/leadership v0.1.0
 	github.com/docker/libkv v0.2.1
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/golang/mock v1.4.0
 	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/consul/api v1.4.0
@@ -14,7 +15,6 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/copystructure v1.0.0
 	github.com/prometheus/client_golang v1.4.1
-	github.com/satori/go.uuid v1.2.0
 	github.com/sgotti/gexpect v0.0.0-20210315095146-1ec64e69809b
 	github.com/sorintlab/pollon v0.0.0-20181009091703-248c68238c16
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
+github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d h1:3PaI8p3seN09VjbTYC/QWlUZdZ1qS1zGjy7LH2Wt07I=
@@ -290,8 +292,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sgotti/gexpect v0.0.0-20210315095146-1ec64e69809b h1:rGT0mqolw5UvjfByF0vWfFEhtL7Hn6P7dNKz7iHBMdA=

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 const (
@@ -50,12 +50,12 @@ var Roles = []Role{
 }
 
 func UID() string {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	return fmt.Sprintf("%x", u[:4])
 }
 
 func UUID() string {
-	return uuid.NewV4().String()
+	return uuid.Must(uuid.NewV4()).String()
 }
 
 const (

--- a/tests/integration/config_test.go
+++ b/tests/integration/config_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 func TestServerParameters(t *testing.T) {
@@ -52,7 +52,7 @@ func TestServerParameters(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
@@ -149,7 +149,7 @@ func TestWalLevel(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
@@ -264,7 +264,7 @@ func TestWalKeepSegments(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
@@ -437,7 +437,7 @@ func TestAlterSystem(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
@@ -509,7 +509,7 @@ func TestAdditionalReplicationSlots(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, false, false, nil)
 	defer shutdown(tks, tss, tp, tstore)
@@ -658,7 +658,7 @@ func TestAutomaticPgRestart(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
@@ -782,7 +782,7 @@ func TestAdvertise(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 

--- a/tests/integration/ha_test.go
+++ b/tests/integration/ha_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
 	pg "github.com/sorintlab/stolon/internal/postgresql"
@@ -70,7 +70,7 @@ func TestInitWithMultipleKeepers(t *testing.T) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
@@ -333,7 +333,7 @@ func testMasterStandby(t *testing.T, syncRepl bool) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, syncRepl, false, nil)
 	defer shutdown(tks, tss, tp, tstore)
@@ -388,7 +388,7 @@ func testFailover(t *testing.T, syncRepl bool, standbyCluster bool) {
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -397,7 +397,7 @@ func testFailover(t *testing.T, syncRepl bool, standbyCluster bool) {
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, syncRepl, false, ptk)
 	defer shutdown(tks, tss, tp, tstore)
@@ -499,7 +499,7 @@ func testFailoverFailed(t *testing.T, syncRepl bool, standbyCluster bool) {
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -508,7 +508,7 @@ func testFailoverFailed(t *testing.T, syncRepl bool, standbyCluster bool) {
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, syncRepl, false, ptk)
 	defer shutdown(tks, tss, tp, tstore)
@@ -611,7 +611,7 @@ func testFailoverTooMuchLag(t *testing.T, standbyCluster bool) {
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -620,7 +620,7 @@ func testFailoverTooMuchLag(t *testing.T, standbyCluster bool) {
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, false, false, ptk)
 	defer shutdown(tks, tss, tp, tstore)
@@ -690,7 +690,7 @@ func testOldMasterRestart(t *testing.T, syncRepl, minSync0 bool, usePgrewind boo
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -699,7 +699,7 @@ func testOldMasterRestart(t *testing.T, syncRepl, minSync0 bool, usePgrewind boo
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	specOptions := []optionSetter{
 		withMinSync0(minSync0),
@@ -844,7 +844,7 @@ func testPartition1(t *testing.T, syncRepl, minSync0, usePgrewind bool, standbyC
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -853,7 +853,7 @@ func testPartition1(t *testing.T, syncRepl, minSync0, usePgrewind bool, standbyC
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	specOptions := []optionSetter{
 		withMinSync0(minSync0),
@@ -1010,7 +1010,7 @@ func testTimelineFork(t *testing.T, syncRepl, usePgrewind bool) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, syncRepl, usePgrewind, nil)
 	defer shutdown(tks, tss, tp, tstore)
@@ -1206,7 +1206,7 @@ func testMasterChangedAddress(t *testing.T, standbyCluster bool) {
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -1215,7 +1215,7 @@ func testMasterChangedAddress(t *testing.T, standbyCluster bool) {
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, false, false, ptk)
 	defer shutdown(tks, tss, tp, tstore)
@@ -1301,7 +1301,7 @@ func TestFailedStandby(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:             cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
@@ -1392,7 +1392,7 @@ func TestLoweredMaxStandbysPerSender(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:             cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
@@ -1457,7 +1457,7 @@ func TestKeeperRemoval(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:           cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
@@ -1565,7 +1565,7 @@ func testKeeperRemovalStolonCtl(t *testing.T, syncRepl bool) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:               cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
@@ -1691,7 +1691,7 @@ func TestStandbyCantSync(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:           cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
@@ -1821,7 +1821,7 @@ func TestDisappearedKeeperData(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, false, false, nil)
 	defer shutdown(tks, tss, tp, tstore)
@@ -1905,7 +1905,7 @@ func testForceFail(t *testing.T, syncRepl bool, standbyCluster bool) {
 	var ptk *TestKeeper
 	var primary *TestKeeper
 	if standbyCluster {
-		primaryClusterName := uuid.NewV4().String()
+		primaryClusterName := uuid.Must(uuid.NewV4()).String()
 		ptks, ptss, ptp, ptstore := setupServers(t, primaryClusterName, dir, 1, 1, false, false, nil)
 		defer shutdown(ptks, ptss, ptp, ptstore)
 		for _, ptk = range ptks {
@@ -1914,7 +1914,7 @@ func testForceFail(t *testing.T, syncRepl bool, standbyCluster bool) {
 		primary = ptk
 	}
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tks, tss, tp, tstore := setupServers(t, clusterName, dir, 2, 1, syncRepl, false, ptk)
 	defer shutdown(tks, tss, tp, tstore)
@@ -2017,7 +2017,7 @@ func testSyncStandbyNotInSync(t *testing.T, minSync0 bool) {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	defer os.RemoveAll(dir)
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 	clusterOpts := []optionSetter{
 		withMinSync0(minSync0),
 	}

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
@@ -43,7 +43,7 @@ func TestInit(t *testing.T) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	initialClusterSpec := &cluster.ClusterSpec{
 		InitMode:           cluster.ClusterInitModeP(cluster.ClusterInitModeNew),
@@ -92,7 +92,7 @@ func TestInitNewNoMerge(t *testing.T) {
 }
 
 func testInitNew(t *testing.T, merge bool) {
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -171,7 +171,7 @@ func TestInitExistingNoMerge(t *testing.T) {
 }
 
 func testInitExisting(t *testing.T, merge bool) {
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -317,7 +317,7 @@ func TestInitUsers(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
 	// Test pg-repl-username == pg-su-username but password different
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 	tk, err := NewTestKeeper(t, dir, clusterName, "user01", "password01", "user01", "password02", tstore.storeBackend, storeEndpoints)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -331,7 +331,7 @@ func TestInitUsers(t *testing.T) {
 	}
 
 	// Test pg-repl-username == pg-su-username
-	clusterName = uuid.NewV4().String()
+	clusterName = uuid.Must(uuid.NewV4()).String()
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 
 	sm := store.NewKVBackedStore(tstore.store, storePath)
@@ -374,7 +374,7 @@ func TestInitUsers(t *testing.T) {
 	}
 
 	// Test pg-repl-username != pg-su-username and pg-su-password defined
-	clusterName = uuid.NewV4().String()
+	clusterName = uuid.Must(uuid.NewV4()).String()
 	storePath = filepath.Join(common.StorePrefix, clusterName)
 
 	sm = store.NewKVBackedStore(tstore.store, storePath)
@@ -420,7 +420,7 @@ func TestInitialClusterSpec(t *testing.T) {
 	tstore := setupStore(t, dir)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	storePath := filepath.Join(common.StorePrefix, clusterName)
@@ -484,9 +484,9 @@ func TestExclusiveLock(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	id := fmt.Sprintf("%x", u[:4])
 
 	tk1, err := NewTestKeeperWithID(t, dir, id, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, tstore.storeBackend, storeEndpoints)
@@ -540,9 +540,9 @@ func TestPasswordTrailingNewLine(t *testing.T) {
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 	defer tstore.Stop()
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	id := fmt.Sprintf("%x", u[:4])
 
 	pgSUPassword := "stolon_superuserpassword\n"

--- a/tests/integration/pitr_test.go
+++ b/tests/integration/pitr_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 )
 
 func TestPITR(t *testing.T) {
@@ -64,7 +64,7 @@ func testPITR(t *testing.T, recoveryTarget bool) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 

--- a/tests/integration/proxy_test.go
+++ b/tests/integration/proxy_test.go
@@ -24,11 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
-
-	"github.com/satori/go.uuid"
 )
 
 func TestProxyListening(t *testing.T) {
@@ -40,7 +39,7 @@ func TestProxyListening(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tstore, err := NewTestStore(t, dir)
 	if err != nil {

--- a/tests/integration/sentinel_test.go
+++ b/tests/integration/sentinel_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
@@ -45,7 +45,7 @@ func TestSentinelEnabledProxies(t *testing.T) {
 
 	storeEndpoints := fmt.Sprintf("%s:%s", tstore.listenAddress, tstore.port)
 
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	storePath := filepath.Join(common.StorePrefix, clusterName)
 	sm := store.NewKVBackedStore(tstore.store, storePath)

--- a/tests/integration/standby_test.go
+++ b/tests/integration/standby_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/sorintlab/stolon/internal/cluster"
 	"github.com/sorintlab/stolon/internal/common"
 	"github.com/sorintlab/stolon/internal/store"
@@ -38,7 +38,7 @@ func TestInitStandbyCluster(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Setup a remote stolon cluster (with just one keeper and one sentinel)
-	primaryClusterName := uuid.NewV4().String()
+	primaryClusterName := uuid.Must(uuid.NewV4()).String()
 
 	ptstore := setupStore(t, dir)
 	defer ptstore.Stop()
@@ -87,7 +87,7 @@ func TestInitStandbyCluster(t *testing.T) {
 	}
 
 	// setup a standby cluster
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tstore := setupStore(t, dir)
 	defer tstore.Stop()
@@ -171,7 +171,7 @@ func TestPromoteStandbyCluster(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Setup a remote stolon cluster (with just one keeper and one sentinel)
-	primaryClusterName := uuid.NewV4().String()
+	primaryClusterName := uuid.Must(uuid.NewV4()).String()
 
 	ptstore := setupStore(t, dir)
 	defer ptstore.Stop()
@@ -220,7 +220,7 @@ func TestPromoteStandbyCluster(t *testing.T) {
 	}
 
 	// setup a standby cluster
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tstore := setupStore(t, dir)
 	defer tstore.Stop()
@@ -320,7 +320,7 @@ func TestPromoteStandbyClusterArchiveRecovery(t *testing.T) {
 	}
 
 	// Setup a remote stolon cluster (with just one keeper and one sentinel)
-	primaryClusterName := uuid.NewV4().String()
+	primaryClusterName := uuid.Must(uuid.NewV4()).String()
 
 	ptstore := setupStore(t, dir)
 	defer ptstore.Stop()
@@ -373,7 +373,7 @@ func TestPromoteStandbyClusterArchiveRecovery(t *testing.T) {
 	}
 
 	// setup a standby cluster
-	clusterName := uuid.NewV4().String()
+	clusterName := uuid.Must(uuid.NewV4()).String()
 
 	tstore := setupStore(t, dir)
 	defer tstore.Stop()

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -39,8 +39,8 @@ import (
 	"github.com/sorintlab/stolon/internal/store"
 	"github.com/sorintlab/stolon/internal/util"
 
+	"github.com/gofrs/uuid"
 	_ "github.com/lib/pq"
-	uuid "github.com/satori/go.uuid"
 	"github.com/sgotti/gexpect"
 )
 
@@ -422,7 +422,7 @@ func NewTestKeeperWithID(t *testing.T, dir, uid, clusterName, pgSUUsername, pgSU
 }
 
 func NewTestKeeper(t *testing.T, dir, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword string, storeBackend store.Backend, storeEndpoints string, a ...string) (*TestKeeper, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	return NewTestKeeperWithID(t, dir, uid, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword, storeBackend, storeEndpoints, a...)
@@ -709,7 +709,7 @@ type TestSentinel struct {
 }
 
 func NewTestSentinel(t *testing.T, dir string, clusterName string, storeBackend store.Backend, storeEndpoints string, a ...string) (*TestSentinel, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	args := []string{}
@@ -748,7 +748,7 @@ type TestProxy struct {
 }
 
 func NewTestProxy(t *testing.T, dir string, clusterName, pgSUUsername, pgSUPassword, pgReplUsername, pgReplPassword string, storeBackend store.Backend, storeEndpoints string, a ...string) (*TestProxy, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	listenAddress, port, err := getFreePort(true, false)
@@ -937,7 +937,7 @@ func NewTestStore(t *testing.T, dir string, a ...string) (*TestStore, error) {
 }
 
 func NewTestEtcd(t *testing.T, dir string, backend store.Backend, a ...string) (*TestStore, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	dataDir := filepath.Join(dir, fmt.Sprintf("etcd%s", uid))
@@ -995,7 +995,7 @@ func NewTestEtcd(t *testing.T, dir string, backend store.Backend, a ...string) (
 }
 
 func NewTestConsul(t *testing.T, dir string, a ...string) (*TestStore, error) {
-	u := uuid.NewV4()
+	u := uuid.Must(uuid.NewV4())
 	uid := fmt.Sprintf("%x", u[:4])
 
 	dataDir := filepath.Join(dir, fmt.Sprintf("consul%s", uid))


### PR DESCRIPTION
Replace the github.com/satori/go.uuid package with the github.com/google/uuid
package to work around the GO-2020-0018 vulnerability.
The vulnerability is fixed in https://github.com/satori/go.uuid/pull/75,
but a release has never been tagged.