### PR TITLE
*: add support for PostgreSQL 15

### DIFF
--- a/.agola/config.jsonnet
+++ b/.agola/config.jsonnet
@@ -172,15 +172,15 @@ local task_build_push_images(name, pgversions, istag, push) =
           task_integration_tests(store, pgversion, 'amd64'),
         ]
         for store in ['etcdv2', 'consul']
-        for pgversion in ['14']
+        for pgversion in ['15']
       ]) + std.flattenArrays([
         [
           task_integration_tests(store, pgversion, 'amd64'),
         ]
         for store in ['etcdv3']
-        for pgversion in [ '10', '11', '12', '13', '14']
+        for pgversion in ['10', '11', '12', '13', '14', '15']
       ]) + [
-        task_build_push_images('test build docker "stolon" images', '10 11 12 13 14', false, false)
+        task_build_push_images('test build docker "stolon" images', '10 11 12 13 14 15', false, false)
         + {
           when: {
             branch: {
@@ -190,13 +190,13 @@ local task_build_push_images(name, pgversions, istag, push) =
             ref: '#refs/pull/\\d+/head#',
           },
         },
-        task_build_push_images('build and push docker "stolon" master branch images', '10 11 12 13 14', false, true)
+        task_build_push_images('build and push docker "stolon" master branch images', '10 11 12 13 14 15', false, true)
         + {
           when: {
             branch: 'master',
           },
         },
-        task_build_push_images('build and push docker "stolon" tag images', '10 11 12 13 14', true, true)
+        task_build_push_images('build and push docker "stolon" tag images', '10 11 12 13 14 15', true, true)
         + {
           when: {
             tag: '#v.*#',

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Anyway it's quite easy to reset a cluster from scratch keeping the current maste
 
 ## Requirements
 
-* PostgreSQL 14, 13, 12, 11, 10, 9.6
+* PostgreSQL 15, 14, 13, 12, 11, 10, 9.6
 * etcd2 >= v2.0, etcd3 >= v3.0, consul >= v0.6 or kubernetes >= 1.8 (based on the store you're going to use)
 
 * OS: currently stolon is tested on GNU/Linux (with reports of people using it also on Solaris, *BSD and Darwin)


### PR DESCRIPTION
Now that [Postgres 15](https://www.postgresql.org/docs/15/release-15.html) is out, it will be good to support it.